### PR TITLE
fix: implement a classical useSub() and move update logic into observer component

### DIFF
--- a/packages/teamplay/index.js
+++ b/packages/teamplay/index.js
@@ -14,7 +14,7 @@ export { GLOBAL_ROOT_ID } from './orm/Root.js'
 export const $ = _getRootSignal({ rootId: GLOBAL_ROOT_ID, rootFunction: universal$ })
 export default $
 export { default as sub } from './orm/sub.js'
-export { default as useSub } from './react/useSub.js'
+export { default as useSub, setUseDeferredValue as __setUseDeferredValue } from './react/useSub.js'
 export { default as observer } from './react/observer.js'
 export { connection, setConnection, getConnection, fetchOnly, setFetchOnly, publicOnly, setPublicOnly } from './orm/connection.js'
 export { GUID_PATTERN, hasMany, hasOne, hasManyFlags, belongsTo, pickFormFields } from '@teamplay/schema'

--- a/packages/teamplay/react/helpers.js
+++ b/packages/teamplay/react/helpers.js
@@ -23,8 +23,21 @@ export function pipeComponentMeta (SourceComponent, TargetComponent, suffix = ''
 }
 
 export function useId () {
-  const { componentId } = useContext(ComponentMetaContext)
-  return componentId
+  const context = useContext(ComponentMetaContext)
+  if (!context) throw Error(ERRORS.useId)
+  return context.componentId
+}
+
+export function useTriggerUpdate () {
+  const context = useContext(ComponentMetaContext)
+  if (!context) throw Error(ERRORS.useTriggerUpdate)
+  return context.triggerUpdate
+}
+
+export function useScheduleUpdate () {
+  const context = useContext(ComponentMetaContext)
+  if (!context) throw Error(ERRORS.useScheduleUpdate)
+  return context.scheduleUpdate
 }
 
 export function useUnmount (fn) {
@@ -36,4 +49,19 @@ export function useUnmount (fn) {
     },
     []
   )
+}
+
+const ERRORS = {
+  useTriggerUpdate: `
+    useTriggerUpdate() can only be used inside a component wrapped with observer().
+    You have probably forgot to wrap your component with observer().
+  `,
+  useScheduleUpdate: `
+    useScheduleUpdate() can only be used inside a component wrapped with observer().
+    You have probably forgot to wrap your component with observer().
+  `,
+  useId: `
+    useId() can only be used inside a component wrapped with observer().
+    You have probably forgot to wrap your component with observer().
+  `
 }

--- a/packages/teamplay/react/useSub.js
+++ b/packages/teamplay/react/useSub.js
@@ -1,14 +1,27 @@
 import { useRef, useDeferredValue } from 'react'
 import sub from '../orm/sub.js'
+import { useScheduleUpdate } from './helpers.js'
 
 let TEST_THROTTLING = false
 
-// version of sub() which works as a react hook and throws promise for Suspense
+// experimental feature to leverage useDeferredValue() to handle re-subscriptions.
+// Currently it does lead to issues with extra rerenders and requires further investigation
+let USE_DEFERRED_VALUE = false
+
 export default function useSub (signal, params) {
+  if (USE_DEFERRED_VALUE) {
+    return useSubDeferred(signal, params) // eslint-disable-line react-hooks/rules-of-hooks
+  } else {
+    return useSubClassic(signal, params) // eslint-disable-line react-hooks/rules-of-hooks
+  }
+}
+
+// version of sub() which works as a react hook and throws promise for Suspense
+export function useSubDeferred (signal, params) {
   signal = useDeferredValue(signal)
   params = useDeferredValue(params ? JSON.stringify(params) : undefined)
-  params = params ? JSON.parse(params) : undefined
-  const promiseOrSignal = params ? sub(signal, params) : sub(signal)
+  params = params != null ? JSON.parse(params) : undefined
+  const promiseOrSignal = params != null ? sub(signal, params) : sub(signal)
   // 1. if it's a promise, throw it so that Suspense can catch it and wait for subscription to finish
   if (promiseOrSignal.then) {
     if (TEST_THROTTLING) {
@@ -27,6 +40,40 @@ export default function useSub (signal, params) {
   return promiseOrSignal
 }
 
+// classic version which initially throws promise for Suspense
+// but if we get a promise second time, we return the last signal and wait for promise to resolve
+export function useSubClassic (signal, params) {
+  const $signalRef = useRef()
+  const activePromiseRef = useRef()
+  const scheduleUpdate = useScheduleUpdate()
+  const promiseOrSignal = params != null ? sub(signal, params) : sub(signal)
+  // 1. if it's a promise, throw it so that Suspense can catch it and wait for subscription to finish
+  if (promiseOrSignal.then) {
+    let promise
+    if (TEST_THROTTLING) {
+      // simulate slow network
+      promise = new Promise((resolve, reject) => {
+        setTimeout(() => {
+          promiseOrSignal.then(resolve, reject)
+        }, TEST_THROTTLING)
+      })
+    } else {
+      promise = promiseOrSignal
+    }
+    // first time we just throw the promise to be caught by Suspense
+    if (!$signalRef.current) throw promise
+    // if we already have a previous signal, we return it and wait for new promise to resolve
+    scheduleUpdate(promise)
+    return $signalRef.current
+  }
+  // 2. if it's a signal, we save it into ref to make sure it's not garbage collected while component exists
+  if ($signalRef.current !== promiseOrSignal) {
+    activePromiseRef.current = undefined
+    $signalRef.current = promiseOrSignal
+  }
+  return promiseOrSignal
+}
+
 export function setTestThrottling (ms) {
   if (typeof ms !== 'number') throw Error('setTestThrottling() accepts only a number in ms')
   if (ms === 0) throw Error('setTestThrottling(0) is not allowed, use resetTestThrottling() instead')
@@ -35,4 +82,7 @@ export function setTestThrottling (ms) {
 }
 export function resetTestThrottling () {
   TEST_THROTTLING = false
+}
+export function setUseDeferredValue (value) {
+  USE_DEFERRED_VALUE = value
 }

--- a/packages/teamplay/test_client/react.js
+++ b/packages/teamplay/test_client/react.js
@@ -352,17 +352,17 @@ describe('useSub() for subscribing to queries', () => {
     expect(container.textContent).toBe('John,Jane')
 
     fireEvent.click(container.querySelector('#active'))
-    expect(renders).toBe(4)
+    expect(renders).toBe(3)
     expect(container.textContent).toBe('John,Jane')
     await wait()
-    expect(renders).toBe(4)
+    expect(renders).toBe(3)
     expect(container.textContent).toBe('John,Jane')
     await throttledWait()
-    expect(renders).toBe(5)
+    expect(renders).toBe(4)
     expect(container.textContent).toBe('John')
 
     await wait()
-    expect(renders).toBe(5)
+    expect(renders).toBe(4)
     resetTestThrottling()
 
     // fireEvent.click(container.querySelector('#inactive'))


### PR DESCRIPTION
there seems to be re-rendering issues caused by useDeferredValue.

This is an attempt to fix them by manually handling the re-subscription logic.

In order to achieve this the update logic was also moved into the `observer()` HOC.

## TODO:

add unit tests to `test_client` to test for the memory leaks.