### PR TITLE
backend: pongo-sqlite DB adapter — mongo queries as SQL over SQLite (no full-DB-in-RAM)

### DIFF
--- a/packages/backend/db/index.js
+++ b/packages/backend/db/index.js
@@ -7,16 +7,20 @@ export const {
 } = await getDb({
   mongoUrl: process.env.MONGO_URL,
   disableMongo: process.env.NO_MONGO,
-  isReadonly: process.env.DB_READONLY
+  isReadonly: process.env.DB_READONLY,
+  adapter: process.env.DB_ADAPTER
 })
 
-async function getDb ({ mongoUrl, disableMongo, isReadonly }) {
+async function getDb ({ mongoUrl, disableMongo, isReadonly, adapter }) {
   if (mongoUrl && !disableMongo) {
     console.log('Database: mongo')
     return await import('./mongo.js')
   } else if (isReadonly) {
     console.log('Database: mingo-memory (no data persistency)')
     return await import('./mingo-memory.js')
+  } else if (adapter === 'pongo' || adapter === 'pongo-sqlite') {
+    console.log('Database: pongo-sqlite (mongo queries run as SQL over a local SQLite file)')
+    return await import('./pongo-sqlite.js')
   } else {
     console.log('Database: mingo-sqlite (persist data to a local SQLite file)')
     return await import('./mingo-sqlite.js')

--- a/packages/backend/db/pongo-sqlite.js
+++ b/packages/backend/db/pongo-sqlite.js
@@ -1,7 +1,7 @@
 import { existsSync } from 'fs'
 import { resolve } from 'path'
 import sqlite3 from 'sqlite3'
-import ShareDbPongoSqlite from './sharedb-pongo-sqlite.js'
+import ShareDbPongoSqlite, { docTableName } from './sharedb-pongo-sqlite.js'
 
 const DEFAULT_DB_PATH = './local.db'
 const OPS_TTL_MS = 24 * 60 * 60 * 1000
@@ -56,7 +56,7 @@ async function deleteExpiredOps (sqliteDb) {
   `)
   const cutoff = Date.now() - OPS_TTL_MS
   for (const { name } of tables) {
-    const snapshots = name.slice(0, -'__ops'.length)
+    const snapshots = docTableName(name.slice(0, -'__ops'.length))
     await run(sqliteDb, `
       DELETE FROM "${name.replaceAll('"', '""')}"
       WHERE

--- a/packages/backend/db/pongo-sqlite.js
+++ b/packages/backend/db/pongo-sqlite.js
@@ -1,0 +1,84 @@
+import { existsSync } from 'fs'
+import { resolve } from 'path'
+import sqlite3 from 'sqlite3'
+import ShareDbPongoSqlite from './sharedb-pongo-sqlite.js'
+
+const DEFAULT_DB_PATH = './local.db'
+const OPS_TTL_MS = 24 * 60 * 60 * 1000
+
+export const { db, sqlite } = await getPongoSqliteDb({
+  dbPath: process.env.DB_PATH,
+  loadSnapshotPath: process.env.DB_LOAD_SNAPSHOT
+})
+
+async function getPongoSqliteDb ({ dbPath, loadSnapshotPath }) {
+  if (loadSnapshotPath) {
+    // the mingo-sqlite clone path copies mingo-format tables; a pongo db has a
+    // different (per-collection) layout. Copy the whole file instead.
+    dbPath = resolve(dbPath || DEFAULT_DB_PATH)
+    if (!existsSync(dbPath)) {
+      const { copyFileSync } = await import('fs')
+      const from = resolve(loadSnapshotPath)
+      if (!existsSync(from)) throw Error(`[pongo-sqlite] DB_LOAD_SNAPSHOT file doesn't exist: ${from}`)
+      copyFileSync(from, dbPath)
+      console.log('[pongo-sqlite] Cloned snapshot db:', from, '->', dbPath)
+    }
+  }
+  dbPath = resolve(dbPath || DEFAULT_DB_PATH)
+
+  const db = new ShareDbPongoSqlite({ dbPath })
+
+  // raw handle on the same file for the rest of the stack (express sessions,
+  // file uploads). Pongo's connections run WAL with busy_timeout, mirror that.
+  const sqliteDb = new sqlite3.Database(dbPath)
+  await run(sqliteDb, 'PRAGMA journal_mode = WAL')
+  await run(sqliteDb, 'PRAGMA busy_timeout = 5000')
+  await run(sqliteDb, `
+    CREATE TABLE IF NOT EXISTS files (
+      id TEXT PRIMARY KEY,
+      data BLOB,
+      createdAt TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+    )
+  `)
+
+  await deleteExpiredOps(sqliteDb)
+
+  console.log('Using SQLite DB from file:', dbPath)
+  return { db, sqlite: sqliteDb }
+}
+
+// same policy as the mingo-sqlite adapter: drop ops older than 24h except the
+// latest op of each doc (kept so a resubscribing client one version behind can
+// still catch up without a refetch)
+async function deleteExpiredOps (sqliteDb) {
+  const tables = await all(sqliteDb, `
+    SELECT name FROM sqlite_master WHERE type = 'table' AND name LIKE '%__ops'
+  `)
+  const cutoff = Date.now() - OPS_TTL_MS
+  for (const { name } of tables) {
+    const snapshots = name.slice(0, -'__ops'.length)
+    await run(sqliteDb, `
+      DELETE FROM "${name.replaceAll('"', '""')}"
+      WHERE
+        json_extract(data, '$.op.m.ts') < ?
+        AND
+        json_extract(data, '$.v') < (
+          SELECT json_extract(s.data, '$.v') - 1
+          FROM "${snapshots.replaceAll('"', '""')}" s
+          WHERE s._id = json_extract("${name.replaceAll('"', '""')}".data, '$.d')
+        )
+    `, [cutoff])
+  }
+}
+
+async function run (sqliteDb, sql, params = []) {
+  return await new Promise((resolve, reject) => {
+    sqliteDb.run(sql, params, err => err ? reject(err) : resolve())
+  })
+}
+
+async function all (sqliteDb, sql, params = []) {
+  return await new Promise((resolve, reject) => {
+    sqliteDb.all(sql, params, (err, rows) => err ? reject(err) : resolve(rows))
+  })
+}

--- a/packages/backend/db/sharedb-pongo-sqlite.js
+++ b/packages/backend/db/sharedb-pongo-sqlite.js
@@ -1,0 +1,696 @@
+// ShareDB database adapter backed by Pongo (https://github.com/event-driven-io/Pongo)
+// running directly over a local SQLite file.
+//
+// Unlike the mingo adapter (which loads the WHOLE database into RAM at boot and
+// serves everything from memory with SQLite as a write-through log), this adapter
+// keeps nothing in memory: every read and query runs as SQL over the SQLite file,
+// so process RSS no longer scales with database size.
+//
+// Storage layout (managed by Pongo, one table per collection):
+//   <collection>        - snapshot docs: { _id, v, type, data, m, alive }
+//                         `alive: 1|0` mirrors `type != null` because SQL can't
+//                         test JSON null/missing; tombstones of deleted docs are
+//                         kept (same as sharedb-mongo / the mingo adapter) so a
+//                         recreated doc continues its version numbering.
+//   <collection>__ops   - op docs: { _id: '<docId>.<v>', d, v, op }
+//                         The deterministic primary key makes getOps a pure
+//                         primary-key lookup (no scans) and op writes idempotent.
+//
+// Query execution is two-tier:
+//   1. SQL fast path - filters/sorts Pongo can translate to SQL run in SQLite.
+//   2. JS fallback   - anything else ($or, $ne, regex, null equality, $exists,
+//                      $aggregate, ...) fetches the collection's live docs and
+//                      runs the EXACT same mingo pipeline as the mingo adapter
+//                      (castToSnapshotQuery + Mingo.Query / Mingo.Aggregator),
+//                      so results always match the mingo adapter's semantics.
+//
+// Concurrency: `commit` uses a conditional write as the version arbiter - the
+// snapshot row is replaced only when its stored `v` still equals `snapshot.v - 1`
+// (or inserted for v=1). SQLite serializes writers, so only one concurrent commit
+// per doc version can win; only the winner writes its op.
+import { pongoClient } from '@event-driven-io/pongo'
+import { sqlite3Driver } from '@event-driven-io/pongo/sqlite3'
+import mingo from 'mingo'
+// load all Mingo query operators so fallback semantics match the mingo adapter
+import 'mingo/init/system'
+import sharedb from 'sharedb'
+import Snapshot from 'sharedb/lib/snapshot.js'
+
+const DB = sharedb.DB
+
+// Snapshot properties added to the root doc by `castToDoc()` in sharedb-mongo
+const MONGO_DOC_PROPERTIES = {
+  _id: 'id',
+  _v: 'v',
+  _type: 'type',
+  _m: 'm',
+  _o: 'o'
+}
+
+// Query keys to strip, because Mingo doesn't already ignore them.
+const STRIPPED_QUERY_KEYS = {
+  $comment: true,
+  $hint: true
+}
+
+const OPS_SUFFIX = '__ops'
+// tables in the same SQLite file owned by other parts of the stack
+// (raw `sqlite` export consumers: express sessions, file uploads)
+const RESERVED_COLLECTIONS = ['files', 'sessions']
+
+// sentinel: a filter/sort that can't be translated to Pongo SQL
+const FALLBACK = Symbol('fallback')
+
+// SQLite requires LIMIT before OFFSET; Pongo emits a bare OFFSET when only
+// skip is set, so inject an "unlimited" limit (max SQLite int64-safe JS int)
+const UNLIMITED = Number.MAX_SAFE_INTEGER
+
+const SQL_COMPARISON_OPERATORS = { $eq: true, $gt: true, $gte: true, $lt: true, $lte: true }
+
+export default class ShareDbPongoSqlite extends DB {
+  constructor ({ dbPath, connectionString, ...options } = {}) {
+    super(options)
+    if (!dbPath && !connectionString) throw Error('[sharedb-pongo-sqlite] dbPath or connectionString is required')
+    this.closed = false
+    this.client = pongoClient({
+      driver: sqlite3Driver,
+      connectionString: connectionString || 'file:' + dbPath
+    })
+    this.pongo = this.client.db()
+    this._collections = new Map()
+    this._inflight = new Set()
+  }
+
+  close (callback) {
+    this.closed = true
+    // drain in-flight operations first: a multi-statement operation (e.g.
+    // commit = snapshot write + op write) interrupted mid-sequence by the pool
+    // closing would surface as spurious errors on live client connections
+    Promise.allSettled([...this._inflight])
+      .then(() => this.client.close())
+      .then(() => callback && callback(), err => callback ? callback(err) : console.error(err))
+  }
+
+  // register an operation so close() can wait for it (must be called
+  // synchronously with the promise's creation - no await gap)
+  _run (promise) {
+    this._inflight.add(promise)
+    const remove = () => this._inflight.delete(promise)
+    promise.then(remove, remove)
+    return promise
+  }
+
+  // ShareDB query subscriptions poll on debounce timers that can fire after
+  // Backend.close(); refuse those calls here so they never hit the closed
+  // connection pool (whose internal task rejections would go unhandled)
+  _assertOpen () {
+    if (this.closed) throw new Error('DB is closed')
+  }
+
+  async _snaps (collection) {
+    return await this._collection(collection)
+  }
+
+  async _ops (collection) {
+    return await this._collection(collection + OPS_SUFFIX)
+  }
+
+  async _collection (name) {
+    let entry = this._collections.get(name)
+    if (!entry) {
+      if (RESERVED_COLLECTIONS.includes(name)) {
+        throw Error(`[sharedb-pongo-sqlite] Collection name "${name}" is reserved`)
+      }
+      const col = this.pongo.collection(name)
+      // gate every first use behind an awaited CREATE TABLE: pongo's lazy
+      // auto-migration clears its "should migrate" flag before the CREATE
+      // completes, so concurrent first ops can otherwise race it
+      const ready = col.createCollection().catch(err => {
+        this._collections.delete(name)
+        throw err
+      })
+      entry = { col, ready }
+      this._collections.set(name, entry)
+    }
+    await entry.ready
+    return entry.col
+  }
+
+  // -- writes -----------------------------------------------------------------
+
+  commit (collection, id, op, snapshot, options, callback) {
+    if (typeof callback !== 'function') throw new Error('Callback required')
+    this._run(this._commit(collection, id, op, snapshot)).then(
+      succeeded => callback(null, succeeded),
+      err => callback(err)
+    )
+  }
+
+  async _commit (collection, id, op, snapshot) {
+    this._assertOpen()
+    const snaps = await this._snaps(collection)
+    const doc = snapshotToDoc(snapshot)
+    let succeeded
+    if (snapshot.v === 1) {
+      // create of a brand-new doc: primary key uniqueness is the version arbiter
+      const res = await snaps.insertOne({ _id: id, ...doc })
+      succeeded = !!res.successful
+    } else {
+      // update/delete/recreate: replace succeeds only if the stored version
+      // still matches - one atomic UPDATE, SQLite serializes the writers
+      const res = await snaps.replaceOne({ _id: id, v: snapshot.v - 1 }, doc)
+      succeeded = res.matchedCount > 0
+    }
+    if (!succeeded) return false
+
+    // only the winner of the version arbiter writes its op, so concurrent
+    // commits can't overwrite each other's op log entries
+    const opV = op.v != null ? op.v : snapshot.v - 1
+    const opDoc = { d: id, v: opV, op }
+    const ops = await this._ops(collection)
+    const res = await ops.insertOne({ _id: opId(id, opV), ...opDoc })
+    // a leftover row at this version can only be garbage from a commit whose
+    // process crashed between the two writes - overwrite it
+    if (!res.successful) await ops.replaceOne({ _id: opId(id, opV) }, opDoc)
+    return true
+  }
+
+  // -- snapshots ----------------------------------------------------------------
+
+  getSnapshot (collection, id, fields, options, callback) {
+    const includeMetadata = (fields && fields.$submit) || (options && options.metadata)
+    this._run(this._findSnapshotRow(collection, id)).then(
+      row => callback(null, docToSnapshot(id, row, includeMetadata)),
+      err => callback(err)
+    )
+  }
+
+  async _findSnapshotRow (collection, id) {
+    this._assertOpen()
+    const snaps = await this._snaps(collection)
+    return await snaps.findOne({ _id: id })
+  }
+
+  getSnapshotBulk (collection, ids, fields, options, callback) {
+    const includeMetadata = (fields && fields.$submit) || (options && options.metadata)
+    this._run(this._getSnapshotBulk(collection, ids)).then(rows => {
+      const byId = new Map(rows.map(row => [row._id, row]))
+      const results = Object.create(null)
+      for (const id of ids) results[id] = docToSnapshot(id, byId.get(id), includeMetadata)
+      callback(null, results)
+    }, err => callback(err))
+  }
+
+  async _getSnapshotBulk (collection, ids) {
+    this._assertOpen()
+    const snaps = await this._snaps(collection)
+    return await snaps.find({ _id: { $in: ids } })
+  }
+
+  // -- ops ------------------------------------------------------------------------
+
+  getOps (collection, id, from, to, options, callback) {
+    const includeMetadata = options && options.metadata
+    this._run(this._getOps(collection, id, from, to)).then(rows => {
+      const ops = rows.map(row => {
+        const op = row.op
+        if (!includeMetadata) delete op.m
+        return op
+      })
+      callback(null, ops)
+    }, err => callback(err))
+  }
+
+  async _getOps (collection, id, from, to) {
+    this._assertOpen()
+    if (!from) from = 0
+    if (to == null) {
+      const row = await this._findSnapshotRow(collection, id)
+      to = row ? row.v : 0
+    }
+    if (to <= from) return []
+    const rows = await this._findOpsRange(collection, id, from, to)
+    if (rows.length < to - from) throw new Error('Missing ops')
+    rows.sort((a, b) => a.v - b.v)
+    return rows
+  }
+
+  async _findOpsRange (collection, id, from, to) {
+    const ops = await this._ops(collection)
+    const rows = []
+    // fetch by deterministic primary keys (chunked to stay under the SQLite
+    // bound-parameter limit)
+    const CHUNK = 400
+    for (let start = from; start < to; start += CHUNK) {
+      const ids = []
+      for (let v = start; v < Math.min(start + CHUNK, to); v++) ids.push(opId(id, v))
+      rows.push(...await ops.find({ _id: { $in: ids } }))
+    }
+    return rows
+  }
+
+  deleteOps (collection, id, from, to, options, callback) {
+    this._run(this._deleteOps(collection, id, from, to)).then(
+      () => callback(null),
+      err => callback(err)
+    )
+  }
+
+  async _deleteOps (collection, id, from, to) {
+    const rows = await this._getOps(collection, id, from, to)
+    const ids = rows.map(row => row._id)
+    if (!ids.length) return
+    const ops = await this._ops(collection)
+    await ops.deleteMany({ _id: { $in: ids } })
+  }
+
+  // -- queries ----------------------------------------------------------------------
+
+  query (collection, inputQuery, fields, options, callback) {
+    if (typeof callback !== 'function') throw new Error('Callback required')
+    this._run(this._query(collection, inputQuery, options)).then(
+      result => callback(null, result.snapshots, result.extra),
+      err => callback(err)
+    )
+  }
+
+  async _query (collection, inputQuery, options) {
+    this._assertOpen()
+    const includeMetadata = options && options.metadata
+    if (Array.isArray(inputQuery.$aggregate)) {
+      return await this._queryAggregate(collection, inputQuery.$aggregate)
+    }
+    const parsed = parseQuery(inputQuery)
+    const filter = translateFilter(parsed.query)
+    const sort = parsed.sort == null ? undefined : translateSort(parsed.sort)
+    if (filter !== FALLBACK && sort !== FALLBACK) {
+      return await this._querySql(collection, parsed, filter, sort, includeMetadata)
+    }
+    return await this._queryFallback(collection, parsed, includeMetadata)
+  }
+
+  async _querySql (collection, parsed, filter, sort, includeMetadata) {
+    const snaps = await this._snaps(collection)
+    if (parsed.count) {
+      const extra = await snaps.countDocuments(filter)
+      return { snapshots: [], extra }
+    }
+    const findOptions = {}
+    if (sort) findOptions.sort = sort
+    if (parsed.limit) findOptions.limit = parsed.limit
+    if (parsed.skip) {
+      findOptions.skip = parsed.skip
+      if (!findOptions.limit) findOptions.limit = UNLIMITED
+    }
+    const rows = await snaps.find(filter, findOptions)
+    const snapshots = rows.map(row => docToSnapshot(row._id, row, includeMetadata))
+    return { snapshots }
+  }
+
+  // exact mingo-adapter semantics for whatever SQL can't express: fetch the
+  // live docs once and run the same Mingo.Query the mingo adapter runs
+  async _queryFallback (collection, parsed, includeMetadata) {
+    const snapshots = await this._liveSnapshots(collection)
+    const mingoQuery = new mingo.Query(castToSnapshotQuery(parsed.query))
+    let filtered = snapshots.filter(snapshot => mingoQuery.test(snapshot))
+    if (parsed.sort) sortSnapshots(filtered, parsed.sort)
+    if (parsed.skip) filtered.splice(0, parsed.skip)
+    if (parsed.limit) filtered = filtered.slice(0, parsed.limit)
+    if (parsed.count) return { snapshots: [], extra: filtered.length }
+    if (!includeMetadata) for (const snapshot of filtered) snapshot.m = null
+    return { snapshots: filtered }
+  }
+
+  async _queryAggregate (collection, pipeline) {
+    // NOTE: like the mingo adapter (and real sharedb-mongo), aggregation runs
+    // over ALL stored docs including deleted-doc tombstone stubs
+    const mongoDocs = (await this._allSnapshots(collection)).map(castToMongoDoc)
+    // support $lookup: prefetch every referenced collection so the resolver
+    // (which mingo calls synchronously) has the data ready
+    const lookups = new Map()
+    for (const name of collectLookupCollections(pipeline)) {
+      lookups.set(name, (await this._allSnapshots(name)).map(castToMongoDoc))
+    }
+    const aggregator = new mingo.Aggregator(pipeline, {
+      collectionResolver: name => lookups.get(name) || []
+    })
+    return { snapshots: [], extra: aggregator.run(mongoDocs) }
+  }
+
+  async _liveSnapshots (collection) {
+    const snaps = await this._snaps(collection)
+    const rows = await snaps.find({ alive: 1 })
+    // metadata is included so queries can filter on it; the caller strips it
+    return rows.map(row => docToSnapshot(row._id, row, true))
+  }
+
+  async _allSnapshots (collection) {
+    const snaps = await this._snaps(collection)
+    const rows = await snaps.find({})
+    return rows.map(row => docToSnapshot(row._id, row, true))
+  }
+
+  queryPollDoc (collection, id, query, options, callback) {
+    const includeMetadata = options && options.metadata
+    let mingoQuery
+    try {
+      mingoQuery = new mingo.Query(castToSnapshotQuery(query))
+    } catch (err) {
+      return callback(err)
+    }
+    this._run(this._findSnapshotRow(collection, id)).then(row => {
+      if (!row || !row.alive) return callback(null, false)
+      callback(null, mingoQuery.test(docToSnapshot(id, row, includeMetadata)))
+    }, err => callback(err))
+  }
+
+  canPollDoc (collection, query) {
+    return !(
+      Object.prototype.hasOwnProperty.call(query, '$orderby') ||
+      Object.prototype.hasOwnProperty.call(query, '$sort') ||
+      Object.prototype.hasOwnProperty.call(query, '$limit') ||
+      Object.prototype.hasOwnProperty.call(query, '$skip') ||
+      Object.prototype.hasOwnProperty.call(query, '$count') ||
+      Object.prototype.hasOwnProperty.call(query, '$aggregate')
+    )
+  }
+}
+
+// -- doc <-> snapshot mapping ----------------------------------------------------
+
+function snapshotToDoc (snapshot) {
+  const doc = {
+    v: snapshot.v,
+    type: snapshot.type || null,
+    m: snapshot.m ?? null,
+    alive: snapshot.type ? 1 : 0
+  }
+  // JSON can't hold undefined (deleted docs have no data)
+  if (snapshot.data !== undefined) doc.data = snapshot.data
+  return doc
+}
+
+function docToSnapshot (id, row, includeMetadata) {
+  if (!row) return new Snapshot(id, 0, null, undefined, null)
+  const data = row.alive ? row.data : undefined
+  const m = includeMetadata ? (row.m ?? null) : null
+  return new Snapshot(id, row.v, row.type || null, data, m)
+}
+
+function opId (docId, v) {
+  return docId + '.' + v
+}
+
+// -- query parsing (mirrors the mingo adapter) ------------------------------------
+
+function parseQuery (inputQuery) {
+  const query = { ...inputQuery }
+
+  if (inputQuery.$orderby) {
+    console.warn('Warning: query.$orderby deprecated. Use query.$sort instead.')
+  }
+  const sort = query.$sort || query.$orderby
+  delete query.$sort
+  delete query.$orderby
+
+  const skip = query.$skip
+  delete query.$skip
+
+  const limit = query.$limit
+  delete query.$limit
+
+  const count = query.$count
+  delete query.$count
+
+  // If needed, modify query to exclude "tombstones" left after deleting docs,
+  // using the same approach that sharedb-mongo uses.
+  makeQuerySafe(query)
+
+  return { query, sort, skip, limit, count }
+}
+
+// Build a query object that mimics how the query would be executed if it were
+// made against snapshots persisted with `sharedb-mongo`
+function castToSnapshotQuery (query) {
+  if (!isPlainObjectLoose(query) || Array.isArray(query)) {
+    throw new Error('Invalid mongo query format')
+  }
+
+  const snapshotQuery = {}
+  for (const property in query) {
+    // Ignore $-prefixed keys like $comment and $hint that aren't already
+    // ignored by Mingo. sharedb-mongo would normally map them to cursor calls.
+    if (STRIPPED_QUERY_KEYS[property]) continue
+
+    const propertySegments = property.split('.')
+
+    if (MONGO_DOC_PROPERTIES[propertySegments[0]]) {
+      // Mongo doc property
+      propertySegments[0] = MONGO_DOC_PROPERTIES[propertySegments[0]]
+      snapshotQuery[propertySegments.join('.')] = query[property]
+    } else if (property[0] === '$' && Array.isArray(query[property])) {
+      // top-level boolean operator
+      snapshotQuery[property] = query[property].map(castToSnapshotQuery)
+    } else {
+      // nested `data` document
+      snapshotQuery['data.' + property] = query[property]
+    }
+  }
+  return snapshotQuery
+}
+
+// Support sorting with the Mongo $orderby syntax
+function sortSnapshots (snapshots, orderby) {
+  if (!orderby) return snapshots
+  snapshots.sort((snapshotA, snapshotB) => {
+    for (const key in orderby) {
+      const value = orderby[key]
+      if (value !== 1 && value !== -1) {
+        throw new Error('Invalid $orderby value')
+      }
+      const a = snapshotA.data && snapshotA.data[key]
+      const b = snapshotB.data && snapshotB.data[key]
+      if (a > b) return value
+      if (b > a) return -value
+    }
+    return 0
+  })
+}
+
+/** Casts the Snapshot into a Mongo document object */
+function castToMongoDoc (snapshot) {
+  const doc = Object.assign({}, snapshot.data)
+  doc._id = snapshot.id
+  doc._type = snapshot.type
+  doc._v = snapshot.v
+  doc._m = snapshot.m
+  return doc
+}
+
+function collectLookupCollections (value, found = new Set()) {
+  if (Array.isArray(value)) {
+    for (const item of value) collectLookupCollections(item, found)
+  } else if (isPlainObjectLoose(value)) {
+    if (typeof value.$lookup?.from === 'string') found.add(value.$lookup.from)
+    for (const key in value) collectLookupCollections(value[key], found)
+  }
+  return found
+}
+
+// -- SQL translation ----------------------------------------------------------------
+//
+// Returns a Pongo filter/sort when the query can run as SQL with semantics
+// identical to the mingo adapter, or FALLBACK otherwise. Everything here is
+// deliberately conservative: any construct with even slightly different
+// semantics in SQL (null/missing handling, $ne, array equality, subdocument
+// equality, regex, logical operators) is kicked to the JS fallback.
+
+function translateFilter (query) {
+  const filter = {}
+  for (const key in query) {
+    if (STRIPPED_QUERY_KEYS[key]) continue
+    if (key[0] === '$') return FALLBACK // $or/$and/$nor/$where/...
+    const path = translatePath(key)
+    if (path === FALLBACK) return FALLBACK
+    const condition = translateCondition(query[key])
+    if (condition === FALLBACK) return FALLBACK
+    filter[path] = condition
+  }
+  // exclude deleted-doc tombstones (the SQL twin of makeQuerySafe's
+  // `_type: {$type: 2}`; queries with an explicit _type fall back above)
+  filter.alive = 1
+  return filter
+}
+
+function translatePath (key) {
+  const segments = key.split('.')
+  const head = segments[0]
+  if (head === '_id') return segments.length === 1 ? '_id' : FALLBACK
+  if (head === '_v') { segments[0] = 'v'; return segments.join('.') }
+  if (head === '_m') { segments[0] = 'm'; return segments.join('.') }
+  if (head[0] === '_') return FALLBACK // _type/_o and other unknown meta fields
+  return 'data.' + key
+}
+
+function translateCondition (value) {
+  if (isComparableScalar(value)) return value
+  if (!isPlainObjectLoose(value) || value instanceof RegExp) return FALLBACK
+  const keys = Object.keys(value)
+  if (!keys.length) return FALLBACK // {} is exact-equality in mongo
+  const condition = {}
+  for (const op of keys) {
+    const operand = value[op]
+    if (SQL_COMPARISON_OPERATORS[op]) {
+      // NOTE: $ne is NOT here - in mongo `$ne` also matches docs where the
+      // field is missing, which SQL's `json_extract(...) != x` excludes
+      if (!isComparableScalar(operand)) return FALLBACK
+      condition[op] = operand
+    } else if (op === '$in') {
+      // ($nin matches missing fields in mongo - fallback territory)
+      if (!Array.isArray(operand) || !operand.every(isComparableScalar)) return FALLBACK
+      if (!operand.length) return FALLBACK
+      condition[op] = operand
+    } else {
+      return FALLBACK
+    }
+  }
+  return condition
+}
+
+function isComparableScalar (value) {
+  const type = typeof value
+  return type === 'string' || type === 'number' || type === 'boolean'
+}
+
+function translateSort (sort) {
+  if (!isPlainObjectLoose(sort)) return FALLBACK
+  const out = {}
+  for (const key in sort) {
+    const value = sort[key]
+    // invalid values throw in the JS comparator - keep that behavior
+    if (value !== 1 && value !== -1) return FALLBACK
+    // the mingo adapter sorts on the SHALLOW `data[key]` (a dotted key is a
+    // literal property name there, not a path) and `_`-prefixed meta keys
+    // would also read from `data` - both mean something else in SQL
+    if (key.includes('.') || key[0] === '_' || key[0] === '$') return FALLBACK
+    out['data.' + key] = value
+  }
+  return out
+}
+
+function isPlainObjectLoose (value) {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+// -- makeQuerySafe (taken straight from sharedb-mongo) -------------------------------
+
+// Call on a query after it gets parsed to make it safe against
+// matching deleted documents.
+function makeQuerySafe (query) {
+  // Don't modify the query if the user explicitly sets _type already
+  if (Object.prototype.hasOwnProperty.call(query, '_type')) return
+  // Deleted documents are kept around so that we can start their version from
+  // the last version if they get recreated. When docs are deleted, their data
+  // properties are cleared and _type is set to null. Filter out deleted docs
+  // by requiring that _type is a string if the query does not naturally
+  // restrict the results with other keys
+  if (deletedDocCouldSatisfyQuery(query)) {
+    query._type = { $type: 2 }
+  }
+}
+
+// Could a deleted doc (one that contains {_type: null} and no other
+// fields) satisfy a query?
+//
+// Return true if it definitely can, or if we're not sure.
+function deletedDocCouldSatisfyQuery (query) {
+  if (Object.prototype.hasOwnProperty.call(query, '$and')) {
+    if (Array.isArray(query.$and)) {
+      for (const clause of query.$and) {
+        if (!deletedDocCouldSatisfyQuery(clause)) return false
+      }
+    } else {
+      // Malformed? Play it safe.
+      return true
+    }
+  }
+
+  for (const prop in query) {
+    // Ignore fields that remain set on deleted docs
+    if (
+      prop === '_id' ||
+      prop === '_v' ||
+      prop === '_o' ||
+      prop === '_m' || (
+        prop[0] === '_' &&
+        prop[1] === 'm' &&
+        prop[2] === '.'
+      )
+    ) continue
+    // Top-level operators with special handling in this function
+    if (prop === '$and' || prop === '$or') continue
+    // When using top-level operators that we don't understand, play it safe
+    if (prop[0] === '$') return true
+    if (!couldMatchNull(query[prop])) return false
+  }
+
+  if (Object.prototype.hasOwnProperty.call(query, '$or')) {
+    if (Array.isArray(query.$or)) {
+      for (const clause of query.$or) {
+        if (deletedDocCouldSatisfyQuery(clause)) return true
+      }
+      return false
+    } else {
+      // Malformed? Play it safe.
+      return true
+    }
+  }
+
+  return true
+}
+
+function couldMatchNull (clause) {
+  if (
+    typeof clause === 'number' ||
+    typeof clause === 'boolean' ||
+    typeof clause === 'string'
+  ) {
+    return false
+  } else if (clause === null) {
+    return true
+  } else if (isPlainObject(clause)) {
+    // Mongo interprets clauses with multiple properties with an
+    // implied 'and' relationship, e.g. {$gt: 3, $lt: 6}. If every
+    // part of the clause could match null then the full clause could
+    // match null.
+    for (const prop in clause) {
+      const value = clause[prop]
+      if (prop === '$in' && Array.isArray(value)) {
+        if (!value.some(item => item === null)) return false
+      } else if (prop === '$ne') {
+        if (value === null) return false
+      } else if (prop === '$exists') {
+        if (value) return false
+      } else if (prop === '$gt' || prop === '$gte' || prop === '$lt' || prop === '$lte') {
+        if (value !== null) return false
+      }
+      // else: not sure what to do with this part of the clause; assume it
+      // could match null.
+    }
+    // All parts of the clause could match null.
+    return true
+  } else {
+    // Not a POJO, string, number, or boolean. Not sure what it is,
+    // but play it safe.
+    return true
+  }
+}
+
+function isPlainObject (value) {
+  return (
+    typeof value === 'object' && value !== null && (
+      Object.getPrototypeOf(value) === Object.prototype ||
+      Object.getPrototypeOf(value) === null
+    )
+  )
+}

--- a/packages/backend/db/sharedb-pongo-sqlite.js
+++ b/packages/backend/db/sharedb-pongo-sqlite.js
@@ -54,9 +54,17 @@ const STRIPPED_QUERY_KEYS = {
 }
 
 const OPS_SUFFIX = '__ops'
-// tables in the same SQLite file owned by other parts of the stack
-// (raw `sqlite` export consumers: express sessions, file uploads)
-const RESERVED_COLLECTIONS = ['files', 'sessions']
+// table names in the same SQLite file owned by other parts of the stack
+// (raw `sqlite` export consumers: express sessions store, file-upload blobs).
+// A ShareDB collection with one of these names gets a remapped table so both
+// can coexist (e.g. the startupjs files plugin keeps blobs in the raw `files`
+// table AND file metadata docs in a `files` ShareDB collection).
+const RESERVED_TABLE_NAMES = { files: 'files__docs', sessions: 'sessions__docs' }
+
+// resolve the snapshots table name for a ShareDB collection
+export function docTableName (collection) {
+  return RESERVED_TABLE_NAMES[collection] || collection
+}
 
 // sentinel: a filter/sort that can't be translated to Pongo SQL
 const FALLBACK = Symbol('fallback')
@@ -108,7 +116,7 @@ export default class ShareDbPongoSqlite extends DB {
   }
 
   async _snaps (collection) {
-    return await this._collection(collection)
+    return await this._collection(docTableName(collection))
   }
 
   async _ops (collection) {
@@ -118,9 +126,6 @@ export default class ShareDbPongoSqlite extends DB {
   async _collection (name) {
     let entry = this._collections.get(name)
     if (!entry) {
-      if (RESERVED_COLLECTIONS.includes(name)) {
-        throw Error(`[sharedb-pongo-sqlite] Collection name "${name}" is reserved`)
-      }
       const col = this.pongo.collection(name)
       // gate every first use behind an awaited CREATE TABLE: pongo's lazy
       // auto-migration clears its "should migrate" flag before the CREATE

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -11,7 +11,11 @@
   "exports": {
     ".": "./index.js"
   },
+  "scripts": {
+    "test": "mocha test/*.js"
+  },
   "dependencies": {
+    "@event-driven-io/pongo": "0.17.0-beta.39",
     "@startupjs/sharedb-mingo-memory": "^4.0.0-2",
     "@teamplay/schema": "^0.5.0",
     "@teamplay/server-aggregate": "^0.5.0",
@@ -21,6 +25,7 @@
     "@types/ioredis-mock": "^8.2.5",
     "ioredis": "^5.3.2",
     "ioredis-mock": "^8.9.0",
+    "mingo": "^6.4.15",
     "mongodb": "^6.0.0",
     "redis": "^5.0.0",
     "redlock": "^3.0.0",
@@ -28,6 +33,13 @@
     "sharedb-hooks": "~4.0.0",
     "sharedb-mongo": "^4.1.2",
     "sharedb-redis-pubsub": "^5.1.0",
-    "sqlite3": "^5.1.6"
+    "sqlite3": "^6.0.1"
+  },
+  "devDependencies": {
+    "chai": "^4.4.1",
+    "mocha": "^11.7.5",
+    "ot-json1": "^1.0.2",
+    "rich-text": "^4.1.0",
+    "sinon": "^15.2.0"
   }
 }

--- a/packages/backend/test/pongo-sqlite.js
+++ b/packages/backend/test/pongo-sqlite.js
@@ -1,0 +1,246 @@
+// Runs the standard ShareDB DB conformance suite against the pongo-sqlite
+// adapter (the same suite @startupjs/sharedb-mingo-memory runs), plus a
+// differential test that executes an identical query battery against both the
+// mingo adapter and the pongo adapter and requires identical results.
+import { createRequire } from 'module'
+import { mkdtempSync, rmSync } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import ShareDbPongoSqlite from '../db/sharedb-pongo-sqlite.js'
+
+const require = createRequire(import.meta.url)
+const { expect } = require('chai')
+const ShareDBMingo = require('@startupjs/sharedb-mingo-memory')
+const Backend = require('sharedb')
+
+const tmp = mkdtempSync(join(tmpdir(), 'sharedb-pongo-test-'))
+let fileCounter = 0
+const liveDbs = []
+
+function createPongoDb () {
+  const db = new ShareDbPongoSqlite({ dbPath: join(tmp, `db-${fileCounter++}.db`) })
+  liveDbs.push(db)
+  return db
+}
+
+after(async () => {
+  for (const db of liveDbs) {
+    if (!db.closed) await new Promise(resolve => db.close(resolve))
+  }
+  rmSync(tmp, { recursive: true, force: true })
+})
+
+// Given a key/value comparison query, return a query object with that filter
+// and a specified sort order ([['foo', 1], ['bar', -1]]). Same mapper the
+// mingo adapter passes to the suite.
+function getQuery ({ query, sort }) {
+  if (sort && sort.length > 0) {
+    const mongoSort = {}
+    for (const [field, direction] of sort) mongoSort[field] = direction
+    return { ...query, $sort: mongoSort }
+  }
+  return query
+}
+
+require('sharedb/test/db')({
+  create (callback) {
+    callback(null, createPongoDb())
+  },
+  getQuery
+})
+
+describe('pongo-sqlite specifics', function () {
+  this.timeout(10000)
+
+  it('rejects an $aggregate-free unsupported top-level operator via mingo parity', done => {
+    const db = createPongoDb()
+    db.query('testcollection', { $mapReduce: [] }, null, null, err => {
+      expect(err).an('error')
+      done()
+    })
+  })
+
+  it('persists across adapter restarts on the same file', done => {
+    const dbPath = join(tmp, 'restart.db')
+    const db1 = new ShareDbPongoSqlite({ dbPath })
+    liveDbs.push(db1)
+    const backend1 = new Backend({ db: db1 })
+    const connection1 = backend1.connect()
+    const doc = connection1.get('col', 'doc1')
+    doc.create({ title: 'persisted' }, err => {
+      if (err) return done(err)
+      db1.close(() => {
+        const db2 = new ShareDbPongoSqlite({ dbPath })
+        liveDbs.push(db2)
+        db2.getSnapshot('col', 'doc1', null, null, (err, snapshot) => {
+          if (err) return done(err)
+          expect(snapshot.v).to.equal(1)
+          expect(snapshot.data).to.eql({ title: 'persisted' })
+          done()
+        })
+      })
+    })
+  })
+
+  it('keeps version numbering across delete + recreate (tombstones)', done => {
+    const db = createPongoDb()
+    const backend = new Backend({ db })
+    const connection = backend.connect()
+    const doc = connection.get('col', 'doc1')
+    doc.create({ n: 1 }, err => {
+      if (err) return done(err)
+      doc.del(err => {
+        if (err) return done(err)
+        db.getSnapshot('col', 'doc1', null, null, (err, snapshot) => {
+          if (err) return done(err)
+          expect(snapshot.v).to.equal(2)
+          expect(snapshot.type).to.equal(null)
+          doc.create({ n: 2 }, err => {
+            if (err) return done(err)
+            db.getSnapshot('col', 'doc1', null, null, (err, snapshot) => {
+              if (err) return done(err)
+              expect(snapshot.v).to.equal(3)
+              expect(snapshot.data).to.eql({ n: 2 })
+              done()
+            })
+          })
+        })
+      })
+    })
+  })
+
+  it('refuses a commit with a stale version (concurrency arbiter)', done => {
+    const db = createPongoDb()
+    const backend = new Backend({ db })
+    const connection = backend.connect()
+    const doc = connection.get('col', 'doc1')
+    doc.create({ n: 1 }, err => {
+      if (err) return done(err)
+      const op = { v: 1, op: [{ p: ['n'], na: 1 }], m: { ts: Date.now() } }
+      const snapshot = { id: 'doc1', v: 2, type: doc.type.uri, data: { n: 2 }, m: null }
+      db.commit('col', 'doc1', op, snapshot, null, (err, succeeded) => {
+        if (err) return done(err)
+        expect(succeeded).to.equal(true)
+        // same version again - must lose the arbiter
+        db.commit('col', 'doc1', op, snapshot, null, (err, succeeded) => {
+          if (err) return done(err)
+          expect(succeeded).to.equal(false)
+          done()
+        })
+      })
+    })
+  })
+})
+
+describe('differential: pongo-sqlite vs mingo (identical query battery)', function () {
+  this.timeout(30000)
+
+  const DOCS = [
+    { id: 'a', data: { kind: 'fruit', name: 'apple', price: 3, tags: ['red', 'sweet'], meta: { origin: 'PL' }, ok: true } },
+    { id: 'b', data: { kind: 'fruit', name: 'banana', price: 1, tags: ['yellow'] } },
+    { id: 'c', data: { kind: 'veg', name: 'carrot', price: 2, archived: true } },
+    { id: 'd', data: { kind: 'fruit', name: 'date', price: 7, rating: null } },
+    { id: 'e', data: { kind: 'veg', name: 'endive', price: 7 } },
+    { id: 'deleted-doc', data: { kind: 'ghost', name: 'gone', price: 100 } }
+  ]
+
+  // battery spanning the SQL fast path AND every fallback trigger
+  const QUERIES = [
+    {},
+    { kind: 'fruit' },
+    { name: 'apple' },
+    { ok: true },
+    { price: { $gt: 2 } },
+    { price: { $gte: 2, $lt: 7 } },
+    { kind: { $in: ['veg', 'ghost'] } },
+    { kind: { $nin: ['veg'] } }, // fallback: $nin matches missing fields in mongo
+    { kind: { $ne: 'veg' } }, // fallback: $ne matches missing fields in mongo
+    { archived: { $ne: true } }, // fallback: must include docs without the field
+    { tags: 'red' }, // array-contains
+    { tags: ['red', 'sweet'] }, // fallback: exact array equality
+    { 'meta.origin': 'PL' }, // nested path
+    { meta: { origin: 'PL' } }, // fallback: exact subdocument equality
+    { rating: null }, // fallback: null matches missing fields in mongo
+    { rating: { $exists: true } }, // fallback
+    { rating: { $exists: false } }, // fallback
+    { name: { $regex: '^a' } }, // fallback
+    { $or: [{ name: 'apple' }, { price: 7 }] }, // fallback
+    { $and: [{ kind: 'fruit' }, { price: { $lt: 5 } }] }, // fallback
+    { _id: 'a' },
+    { _id: { $in: ['a', 'c', 'deleted-doc'] } },
+    { price: 100 }, // only the deleted doc had it - must return nothing
+    { kind: 'fruit', $sort: { price: -1 } },
+    { $sort: { price: 1, name: -1 } },
+    { $sort: { price: 1 }, $skip: 1, $limit: 2 },
+    { $sort: { price: 1 }, $skip: 2 },
+    { $limit: 3, $sort: { name: 1 } },
+    { kind: 'fruit', $count: true },
+    { $count: true },
+    { $aggregate: [{ $group: { _id: '$kind', total: { $sum: '$price' } } }, { $sort: { _id: 1 } }] }
+  ]
+
+  let mingoDb, pongoDb
+
+  before(async () => {
+    mingoDb = new ShareDBMingo()
+    pongoDb = createPongoDb()
+    for (const db of [mingoDb, pongoDb]) {
+      const backend = new Backend({ db })
+      const connection = backend.connect()
+      for (const { id, data } of DOCS) {
+        const doc = connection.get('battery', id)
+        await new Promise((resolve, reject) => doc.create(data, err => err ? reject(err) : resolve()))
+      }
+      const doc = connection.get('battery', 'deleted-doc')
+      await new Promise((resolve, reject) => doc.del(err => err ? reject(err) : resolve()))
+    }
+  })
+
+  function runQuery (db, query) {
+    return new Promise((resolve, reject) => {
+      db.query('battery', query, null, null, (err, snapshots, extra) => {
+        if (err) return reject(err)
+        resolve({ snapshots, extra })
+      })
+    })
+  }
+
+  for (const query of QUERIES) {
+    const label = JSON.stringify(query)
+    it(label, async () => {
+      const expected = await runQuery(mingoDb, query)
+      const actual = await runQuery(pongoDb, query)
+      const sorted = '$sort' in query
+      const expectedIds = expected.snapshots.map(s => s.id)
+      const actualIds = actual.snapshots.map(s => s.id)
+      if (sorted) {
+        expect(actualIds).to.eql(expectedIds)
+      } else {
+        expect(actualIds.slice().sort()).to.eql(expectedIds.slice().sort())
+      }
+      // same snapshot contents (data, version, metadata stripped identically)
+      const byId = Object.fromEntries(expected.snapshots.map(s => [s.id, s]))
+      for (const snapshot of actual.snapshots) {
+        expect(snapshot.data).to.eql(byId[snapshot.id].data)
+        expect(snapshot.v).to.equal(byId[snapshot.id].v)
+        expect(snapshot.m).to.eql(byId[snapshot.id].m)
+      }
+      expect(actual.extra).to.eql(expected.extra)
+    })
+  }
+
+  it('queryPollDoc parity', async () => {
+    const cases = [
+      ['a', { kind: 'fruit' }],
+      ['a', { kind: 'veg' }],
+      ['deleted-doc', {}],
+      ['missing', { kind: 'fruit' }]
+    ]
+    for (const [id, query] of cases) {
+      const run = db => new Promise((resolve, reject) => {
+        db.queryPollDoc('battery', id, query, null, (err, matches) => err ? reject(err) : resolve(matches))
+      })
+      expect(await run(pongoDb)).to.equal(await run(mingoDb), JSON.stringify([id, query]))
+    }
+  })
+})

--- a/packages/backend/test/pongo-sqlite.js
+++ b/packages/backend/test/pongo-sqlite.js
@@ -109,6 +109,21 @@ describe('pongo-sqlite specifics', function () {
     })
   })
 
+  it('supports a ShareDB collection named "files" (remapped table, no clash with the raw blob table)', done => {
+    const db = createPongoDb()
+    const backend = new Backend({ db })
+    const connection = backend.connect()
+    const doc = connection.get('files', 'file1')
+    doc.create({ name: 'photo.jpg', storageType: 'sqlite' }, err => {
+      if (err) return done(err)
+      db.query('files', { storageType: 'sqlite' }, null, null, (err, snapshots) => {
+        if (err) return done(err)
+        expect(snapshots.map(s => s.id)).to.eql(['file1'])
+        done()
+      })
+    })
+  })
+
   it('refuses a commit with a stale version (concurrency arbiter)', done => {
     const db = createPongoDb()
     const backend = new Backend({ db })

--- a/yarn.lock
+++ b/yarn.lock
@@ -653,6 +653,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@colors/colors@npm:1.5.0":
+  version: 1.5.0
+  resolution: "@colors/colors@npm:1.5.0"
+  checksum: 10c0/eb42729851adca56d19a08e48d5a1e95efd2a32c55ae0323de8119052be0510d4b7a1611f2abcbf28c044a6c11e6b7d38f99fccdad7429300c37a8ea5fb95b44
+  languageName: node
+  linkType: hard
+
 "@cspotcode/source-map-support@npm:^0.8.0":
   version: 0.8.1
   resolution: "@cspotcode/source-map-support@npm:0.8.1"
@@ -1043,10 +1050,57 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@gar/promisify@npm:^1.0.1":
-  version: 1.1.3
-  resolution: "@gar/promisify@npm:1.1.3"
-  checksum: 10c0/0b3c9958d3cd17f4add3574975e3115ae05dc7f1298a60810414b16f6f558c137b5fb3cd3905df380bacfd955ec13f67c1e6710cbb5c246a7e8d65a8289b2bff
+"@event-driven-io/dumbo@npm:0.13.0-beta.39":
+  version: 0.13.0-beta.39
+  resolution: "@event-driven-io/dumbo@npm:0.13.0-beta.39"
+  dependencies:
+    uuid: "npm:^14.0.0"
+  peerDependencies:
+    "@cloudflare/workers-types": ^4.20260421.1
+    "@types/pg": ^8.20.0
+    pg: ^8.20.0
+    sqlite3: ^6.0.1
+  peerDependenciesMeta:
+    "@cloudflare/workers-types":
+      optional: true
+    "@types/pg":
+      optional: true
+    pg:
+      optional: true
+    sqlite3:
+      optional: true
+  checksum: 10c0/9580e66f4fc2ee8ff8e2d8d9698d1224faa081a5dd031e53b41b2c6e3c6cdcce5218357e7a400796b4eb41d6762523ea39fed687873669ceb4a5c72cc63f5e67
+  languageName: node
+  linkType: hard
+
+"@event-driven-io/pongo@npm:0.17.0-beta.39":
+  version: 0.17.0-beta.39
+  resolution: "@event-driven-io/pongo@npm:0.17.0-beta.39"
+  dependencies:
+    "@event-driven-io/dumbo": "npm:0.13.0-beta.39"
+    "@types/mongodb": "npm:^4.0.7"
+    ansis: "npm:^4.2.0"
+    cli-table3: "npm:^0.6.5"
+    commander: "npm:^14.0.3"
+    lru-cache: "npm:^11.3.5"
+    uuid: "npm:^14.0.0"
+  peerDependencies:
+    "@cloudflare/workers-types": ^4.20260421.1
+    "@types/pg": ^8.20.0
+    pg: ^8.20.0
+    sqlite3: ^6.0.1
+  peerDependenciesMeta:
+    "@cloudflare/workers-types":
+      optional: true
+    "@types/pg":
+      optional: true
+    pg:
+      optional: true
+    sqlite3:
+      optional: true
+  bin:
+    pongo: dist/cli.js
+  checksum: 10c0/3cfdc9740d83f21d530a00f82a69ae7cf3ab61476733fde25e5144c33497d0837999f9a44c37628f6fdeef6a0cb802c4909fae30f5f423dbbb72083271e184df
   languageName: node
   linkType: hard
 
@@ -2036,6 +2090,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@mongodb-js/saslprep@npm:^1.3.0":
+  version: 1.4.12
+  resolution: "@mongodb-js/saslprep@npm:1.4.12"
+  dependencies:
+    sparse-bitfield: "npm:^3.0.3"
+  checksum: 10c0/0958b753bb890f03c963175086a50a599e2d2624e893a7118d86a364901b9b2373a0b8a4c12cec27a961108562e90a58fdfcb3e26c8ccce6a4ace875748a6fc1
+  languageName: node
+  linkType: hard
+
 "@napi-rs/wasm-runtime@npm:0.2.4":
   version: 0.2.4
   resolution: "@napi-rs/wasm-runtime@npm:0.2.4"
@@ -2151,16 +2214,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@npmcli/fs@npm:^1.0.0":
-  version: 1.1.1
-  resolution: "@npmcli/fs@npm:1.1.1"
-  dependencies:
-    "@gar/promisify": "npm:^1.0.1"
-    semver: "npm:^7.3.5"
-  checksum: 10c0/4143c317a7542af9054018b71601e3c3392e6704e884561229695f099a71336cbd580df9a9ffb965d0024bf0ed593189ab58900fd1714baef1c9ee59c738c3e2
-  languageName: node
-  linkType: hard
-
 "@npmcli/fs@npm:^3.1.0":
   version: 3.1.1
   resolution: "@npmcli/fs@npm:3.1.1"
@@ -2266,16 +2319,6 @@ __metadata:
     proc-log: "npm:^6.0.0"
     semver: "npm:^7.3.5"
   checksum: 10c0/cc5905788b0dbd2372beff690566ed917be8643b8c24352e669339f6ee66a6edf4a82ba22c7b88b8fa0c52589556c6aa4613a47825ab3727caee6ae8451ab09a
-  languageName: node
-  linkType: hard
-
-"@npmcli/move-file@npm:^1.0.1":
-  version: 1.1.2
-  resolution: "@npmcli/move-file@npm:1.1.2"
-  dependencies:
-    mkdirp: "npm:^1.0.4"
-    rimraf: "npm:^3.0.2"
-  checksum: 10c0/02e946f3dafcc6743132fe2e0e2b585a96ca7265653a38df5a3e53fcf26c7c7a57fc0f861d7c689a23fdb6d6836c7eea5050c8086abf3c994feb2208d1514ff0
   languageName: node
   linkType: hard
 
@@ -3094,12 +3137,30 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@sinonjs/commons@npm:^3.0.1":
+"@sinonjs/commons@npm:^3.0.0, @sinonjs/commons@npm:^3.0.1":
   version: 3.0.1
   resolution: "@sinonjs/commons@npm:3.0.1"
   dependencies:
     type-detect: "npm:4.0.8"
   checksum: 10c0/1227a7b5bd6c6f9584274db996d7f8cee2c8c350534b9d0141fc662eaf1f292ea0ae3ed19e5e5271c8fd390d27e492ca2803acd31a1978be2cdc6be0da711403
+  languageName: node
+  linkType: hard
+
+"@sinonjs/fake-timers@npm:^10.3.0":
+  version: 10.3.0
+  resolution: "@sinonjs/fake-timers@npm:10.3.0"
+  dependencies:
+    "@sinonjs/commons": "npm:^3.0.0"
+  checksum: 10c0/2e2fb6cc57f227912814085b7b01fede050cd4746ea8d49a1e44d5a0e56a804663b0340ae2f11af7559ea9bf4d087a11f2f646197a660ea3cb04e19efc04aa63
+  languageName: node
+  linkType: hard
+
+"@sinonjs/fake-timers@npm:^11.2.2":
+  version: 11.3.1
+  resolution: "@sinonjs/fake-timers@npm:11.3.1"
+  dependencies:
+    "@sinonjs/commons": "npm:^3.0.1"
+  checksum: 10c0/c4f96ea7c3ab0e1a5fc1e2e1201e984a9302841a9fb10059120ce3b6789dae0f851c8827cf16b052a6f87db9a098cdd36f7067246e7a9b71da1d5a2c3d3a9f3d
   languageName: node
   linkType: hard
 
@@ -3109,6 +3170,23 @@ __metadata:
   dependencies:
     "@sinonjs/commons": "npm:^3.0.1"
   checksum: 10c0/fea39af47e70acf7f6b431b857dc5b50886e1a19d48189bc7f9cf90806a9fdfd4931c04343558724772d429c47fb53df640fc8c8d6ddf6ad66164bd7cbd3220a
+  languageName: node
+  linkType: hard
+
+"@sinonjs/samsam@npm:^8.0.0":
+  version: 8.0.3
+  resolution: "@sinonjs/samsam@npm:8.0.3"
+  dependencies:
+    "@sinonjs/commons": "npm:^3.0.1"
+    type-detect: "npm:^4.1.0"
+  checksum: 10c0/9bf57a8f8a484b3455696786e1679db7f0d6017de62099ee304bd364281fcb20895b7c6b05292aa10fecf76df27691e914fc3e1cb8a56d88c027e87d869dcf0c
+  languageName: node
+  linkType: hard
+
+"@sinonjs/text-encoding@npm:^0.7.2":
+  version: 0.7.3
+  resolution: "@sinonjs/text-encoding@npm:0.7.3"
+  checksum: 10c0/b112d1e97af7f99fbdc63c7dbcd35d6a60764dfec85cfcfff532e55cce8ecd8453f9fa2139e70aea47142c940fd90cd201d19f370b9a0141700d8a6de3116815
   languageName: node
   linkType: hard
 
@@ -3160,6 +3238,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@teamplay/backend@workspace:packages/backend"
   dependencies:
+    "@event-driven-io/pongo": "npm:0.17.0-beta.39"
     "@startupjs/sharedb-mingo-memory": "npm:^4.0.0-2"
     "@teamplay/schema": "npm:^0.5.0"
     "@teamplay/server-aggregate": "npm:^0.5.0"
@@ -3167,16 +3246,22 @@ __metadata:
     "@teamplay/sharedb-schema": "npm:^0.5.0"
     "@teamplay/utils": "npm:^0.5.0"
     "@types/ioredis-mock": "npm:^8.2.5"
+    chai: "npm:^4.4.1"
     ioredis: "npm:^5.3.2"
     ioredis-mock: "npm:^8.9.0"
+    mingo: "npm:^6.4.15"
+    mocha: "npm:^11.7.5"
     mongodb: "npm:^6.0.0"
+    ot-json1: "npm:^1.0.2"
     redis: "npm:^5.0.0"
     redlock: "npm:^3.0.0"
+    rich-text: "npm:^4.1.0"
     sharedb: "npm:5.2.2"
     sharedb-hooks: "npm:~4.0.0"
     sharedb-mongo: "npm:^4.1.2"
     sharedb-redis-pubsub: "npm:^5.1.0"
-    sqlite3: "npm:^5.1.6"
+    sinon: "npm:^15.2.0"
+    sqlite3: "npm:^6.0.1"
   languageName: unknown
   linkType: soft
 
@@ -3292,13 +3377,6 @@ __metadata:
     "@types/react-dom":
       optional: true
   checksum: 10c0/f9c7f0915e1b5f7b750e6c7d8b51f091b8ae7ea99bacb761d7b8505ba25de9cfcb749a0f779f1650fb268b499dd79165dc7e1ee0b8b4cb63430d3ddc81ffe044
-  languageName: node
-  linkType: hard
-
-"@tootallnate/once@npm:1":
-  version: 1.1.2
-  resolution: "@tootallnate/once@npm:1.1.2"
-  checksum: 10c0/8fe4d006e90422883a4fa9339dd05a83ff626806262e1710cee5758d493e8cbddf2db81c0e4690636dc840b02c9fda62877866ea774ebd07c1777ed5fafbdec6
   languageName: node
   linkType: hard
 
@@ -3537,6 +3615,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/mongodb@npm:^4.0.7":
+  version: 4.0.7
+  resolution: "@types/mongodb@npm:4.0.7"
+  dependencies:
+    mongodb: "npm:*"
+  checksum: 10c0/19d7085bd14c01bed06220ba52f1b367048fd340581cb645e7b8da867eff388d20f8a9edb0c6c7c33df8489ce303505f31bb85340e5e36a6a356a60e32c1f04d
+  languageName: node
+  linkType: hard
+
 "@types/ms@npm:*":
   version: 0.7.34
   resolution: "@types/ms@npm:0.7.34"
@@ -3650,6 +3737,15 @@ __metadata:
   dependencies:
     "@types/webidl-conversions": "npm:*"
   checksum: 10c0/7a9b9252dee98df6db1ad62337daca7f59ae50d7a3406d14ac6b57168d406004359994f3371155e24f3cf12002c4cb8bbb0883bd4cefb9d7ee8e2b510bdd7f5e
+  languageName: node
+  linkType: hard
+
+"@types/whatwg-url@npm:^13.0.0":
+  version: 13.0.0
+  resolution: "@types/whatwg-url@npm:13.0.0"
+  dependencies:
+    "@types/webidl-conversions": "npm:*"
+  checksum: 10c0/b7b53ae7b5290a0c26e2a5c6a2353af925fe9fc7ab0bbf642e8b76f65b39f638b471dadfda8da441aed3ca32cafd33b1a03459117c9ec85fd91b1e6c0e93044e
   languageName: node
   linkType: hard
 
@@ -3997,13 +4093,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"abbrev@npm:1":
-  version: 1.1.1
-  resolution: "abbrev@npm:1.1.1"
-  checksum: 10c0/3f762677702acb24f65e813070e306c61fafe25d4b2583f9dfc935131f774863f3addd5741572ed576bd69cabe473c5af18e1e108b829cb7b6b4747884f726e6
-  languageName: node
-  linkType: hard
-
 "abbrev@npm:^2.0.0":
   version: 2.0.0
   resolution: "abbrev@npm:2.0.0"
@@ -4084,15 +4173,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"agent-base@npm:6, agent-base@npm:^6.0.2":
-  version: 6.0.2
-  resolution: "agent-base@npm:6.0.2"
-  dependencies:
-    debug: "npm:4"
-  checksum: 10c0/dc4f757e40b5f3e3d674bc9beb4f1048f4ee83af189bae39be99f57bf1f48dde166a8b0a5342a84b5944ee8e6ed1e5a9d801858f4ad44764e84957122fe46261
-  languageName: node
-  linkType: hard
-
 "agent-base@npm:^7.0.2, agent-base@npm:^7.1.0, agent-base@npm:^7.1.1":
   version: 7.1.1
   resolution: "agent-base@npm:7.1.1"
@@ -4106,15 +4186,6 @@ __metadata:
   version: 7.1.4
   resolution: "agent-base@npm:7.1.4"
   checksum: 10c0/c2c9ab7599692d594b6a161559ada307b7a624fa4c7b03e3afdb5a5e31cd0e53269115b620fcab024c5ac6a6f37fa5eb2e004f076ad30f5f7e6b8b671f7b35fe
-  languageName: node
-  linkType: hard
-
-"agentkeepalive@npm:^4.1.3":
-  version: 4.5.0
-  resolution: "agentkeepalive@npm:4.5.0"
-  dependencies:
-    humanize-ms: "npm:^1.2.1"
-  checksum: 10c0/394ea19f9710f230722996e156607f48fdf3a345133b0b1823244b7989426c16019a428b56c82d3eabef616e938812981d9009f4792ecc66bd6a59e991c62612
   languageName: node
   linkType: hard
 
@@ -4230,6 +4301,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"ansis@npm:^4.2.0":
+  version: 4.3.1
+  resolution: "ansis@npm:4.3.1"
+  checksum: 10c0/d1a48090f9c33b18f254a3496e5336a20391a51140b552a1c0bc38710ae7c8bc36a62658f28759797d7bce15e89b893e9ef1962ea1ea42a291d112263f6e593c
+  languageName: node
+  linkType: hard
+
 "anymatch@npm:^3.1.3, anymatch@npm:~3.1.2":
   version: 3.1.3
   resolution: "anymatch@npm:3.1.3"
@@ -4240,20 +4318,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"aproba@npm:2.0.0, aproba@npm:^1.0.3 || ^2.0.0":
+"aproba@npm:2.0.0":
   version: 2.0.0
   resolution: "aproba@npm:2.0.0"
   checksum: 10c0/d06e26384a8f6245d8c8896e138c0388824e259a329e0c9f196b4fa533c82502a6fd449586e3604950a0c42921832a458bb3aa0aa9f0ba449cfd4f50fd0d09b5
-  languageName: node
-  linkType: hard
-
-"are-we-there-yet@npm:^3.0.0":
-  version: 3.0.1
-  resolution: "are-we-there-yet@npm:3.0.1"
-  dependencies:
-    delegates: "npm:^1.0.0"
-    readable-stream: "npm:^3.6.0"
-  checksum: 10c0/8373f289ba42e4b5ec713bb585acdac14b5702c75f2a458dc985b9e4fa5762bc5b46b40a21b72418a3ed0cfb5e35bdc317ef1ae132f3035f633d581dd03168c3
   languageName: node
   linkType: hard
 
@@ -4460,6 +4528,13 @@ __metadata:
   version: 2.0.1
   resolution: "arrify@npm:2.0.1"
   checksum: 10c0/3fb30b5e7c37abea1907a60b28a554d2f0fc088757ca9bf5b684786e583fdf14360721eb12575c1ce6f995282eab936712d3c4389122682eafab0e0b57f78dbb
+  languageName: node
+  linkType: hard
+
+"assertion-error@npm:^1.1.0":
+  version: 1.1.0
+  resolution: "assertion-error@npm:1.1.0"
+  checksum: 10c0/25456b2aa333250f01143968e02e4884a34588a8538fbbf65c91a637f1dbfb8069249133cd2f4e530f10f624d206a664e7df30207830b659e9f5298b00a4099b
   languageName: node
   linkType: hard
 
@@ -4801,6 +4876,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"bson@npm:^7.2.0":
+  version: 7.3.1
+  resolution: "bson@npm:7.3.1"
+  checksum: 10c0/1fead90b1081704a1844c959320a81669a85aa896eb654913c81ee6f3001c5645cd33f88b37538e3359432129d1b73a98edd8ba2b146e9c82a7f9269f1e73a06
+  languageName: node
+  linkType: hard
+
 "buffer-from@npm:^1.0.0":
   version: 1.1.2
   resolution: "buffer-from@npm:1.1.2"
@@ -4865,32 +4947,6 @@ __metadata:
   version: 6.7.14
   resolution: "cac@npm:6.7.14"
   checksum: 10c0/4ee06aaa7bab8981f0d54e5f5f9d4adcd64058e9697563ce336d8a3878ed018ee18ebe5359b2430eceae87e0758e62ea2019c3f52ae6e211b1bd2e133856cd10
-  languageName: node
-  linkType: hard
-
-"cacache@npm:^15.2.0":
-  version: 15.3.0
-  resolution: "cacache@npm:15.3.0"
-  dependencies:
-    "@npmcli/fs": "npm:^1.0.0"
-    "@npmcli/move-file": "npm:^1.0.1"
-    chownr: "npm:^2.0.0"
-    fs-minipass: "npm:^2.0.0"
-    glob: "npm:^7.1.4"
-    infer-owner: "npm:^1.0.4"
-    lru-cache: "npm:^6.0.0"
-    minipass: "npm:^3.1.1"
-    minipass-collect: "npm:^1.0.2"
-    minipass-flush: "npm:^1.0.5"
-    minipass-pipeline: "npm:^1.2.2"
-    mkdirp: "npm:^1.0.3"
-    p-map: "npm:^4.0.0"
-    promise-inflight: "npm:^1.0.1"
-    rimraf: "npm:^3.0.2"
-    ssri: "npm:^8.0.1"
-    tar: "npm:^6.0.2"
-    unique-filename: "npm:^1.1.1"
-  checksum: 10c0/886fcc0acc4f6fd5cd142d373d8276267bc6d655d7c4ce60726fbbec10854de3395ee19bbf9e7e73308cdca9fdad0ad55060ff3bd16c6d4165c5b8d21515e1d8
   languageName: node
   linkType: hard
 
@@ -5051,6 +5107,21 @@ __metadata:
   languageName: node
   linkType: hard
 
+"chai@npm:^4.4.1":
+  version: 4.5.0
+  resolution: "chai@npm:4.5.0"
+  dependencies:
+    assertion-error: "npm:^1.1.0"
+    check-error: "npm:^1.0.3"
+    deep-eql: "npm:^4.1.3"
+    get-func-name: "npm:^2.0.2"
+    loupe: "npm:^2.3.6"
+    pathval: "npm:^1.1.1"
+    type-detect: "npm:^4.1.0"
+  checksum: 10c0/b8cb596bd1aece1aec659e41a6e479290c7d9bee5b3ad63d2898ad230064e5b47889a3bc367b20100a0853b62e026e2dc514acf25a3c9385f936aa3614d4ab4d
+  languageName: node
+  linkType: hard
+
 "chalk@npm:4.1.0":
   version: 4.1.0
   resolution: "chalk@npm:4.1.0"
@@ -5128,6 +5199,15 @@ __metadata:
   version: 2.1.1
   resolution: "chardet@npm:2.1.1"
   checksum: 10c0/d8391dd412338442b3de0d3a488aa9327f8bcf74b62b8723d6bd0b85c4084d50b731320e0a7c710edb1d44de75969995d2784b80e4c13b004a6c7a0db4c6e793
+  languageName: node
+  linkType: hard
+
+"check-error@npm:^1.0.3":
+  version: 1.0.3
+  resolution: "check-error@npm:1.0.3"
+  dependencies:
+    get-func-name: "npm:^2.0.2"
+  checksum: 10c0/94aa37a7315c0e8a83d0112b5bfb5a8624f7f0f81057c73e4707729cdd8077166c6aefb3d8e2b92c63ee130d4a2ff94bad46d547e12f3238cc1d78342a973841
   languageName: node
   linkType: hard
 
@@ -5251,6 +5331,19 @@ __metadata:
   version: 2.9.2
   resolution: "cli-spinners@npm:2.9.2"
   checksum: 10c0/907a1c227ddf0d7a101e7ab8b300affc742ead4b4ebe920a5bf1bc6d45dce2958fcd195eb28fa25275062fe6fa9b109b93b63bc8033396ed3bcb50297008b3a3
+  languageName: node
+  linkType: hard
+
+"cli-table3@npm:^0.6.5":
+  version: 0.6.5
+  resolution: "cli-table3@npm:0.6.5"
+  dependencies:
+    "@colors/colors": "npm:1.5.0"
+    string-width: "npm:^4.2.0"
+  dependenciesMeta:
+    "@colors/colors":
+      optional: true
+  checksum: 10c0/d7cc9ed12212ae68241cc7a3133c52b844113b17856e11f4f81308acc3febcea7cc9fd298e70933e294dd642866b29fd5d113c2c098948701d0c35f09455de78
   languageName: node
   linkType: hard
 
@@ -5381,7 +5474,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"color-support@npm:1.1.3, color-support@npm:^1.1.3":
+"color-support@npm:1.1.3":
   version: 1.1.3
   resolution: "color-support@npm:1.1.3"
   bin:
@@ -5427,6 +5520,13 @@ __metadata:
   version: 12.1.0
   resolution: "commander@npm:12.1.0"
   checksum: 10c0/6e1996680c083b3b897bfc1cfe1c58dfbcd9842fd43e1aaf8a795fbc237f65efcc860a3ef457b318e73f29a4f4a28f6403c3d653d021d960e4632dd45bde54a9
+  languageName: node
+  linkType: hard
+
+"commander@npm:^14.0.3":
+  version: 14.0.3
+  resolution: "commander@npm:14.0.3"
+  checksum: 10c0/755652564bbf56ff2ff083313912b326450d3f8d8c85f4b71416539c9a05c3c67dbd206821ca72635bf6b160e2afdefcb458e86b317827d5cb333b69ce7f1a24
   languageName: node
   linkType: hard
 
@@ -5792,7 +5892,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"debug@npm:*, debug@npm:4, debug@npm:4.3.4, debug@npm:^4.1.0, debug@npm:^4.1.1, debug@npm:^4.3.1, debug@npm:^4.3.2, debug@npm:^4.3.3, debug@npm:^4.3.4":
+"debug@npm:*, debug@npm:4, debug@npm:4.3.4, debug@npm:^4.1.0, debug@npm:^4.1.1, debug@npm:^4.3.1, debug@npm:^4.3.2, debug@npm:^4.3.4":
   version: 4.3.4
   resolution: "debug@npm:4.3.4"
   dependencies:
@@ -5910,6 +6010,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"deep-eql@npm:^4.1.3":
+  version: 4.1.4
+  resolution: "deep-eql@npm:4.1.4"
+  dependencies:
+    type-detect: "npm:^4.0.0"
+  checksum: 10c0/264e0613493b43552fc908f4ff87b8b445c0e6e075656649600e1b8a17a57ee03e960156fce7177646e4d2ddaf8e5ee616d76bd79929ff593e5c79e4e5e6c517
+  languageName: node
+  linkType: hard
+
 "deep-equal@npm:^1.0.1":
   version: 1.1.2
   resolution: "deep-equal@npm:1.1.2"
@@ -5990,13 +6099,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"delegates@npm:^1.0.0":
-  version: 1.0.0
-  resolution: "delegates@npm:1.0.0"
-  checksum: 10c0/ba05874b91148e1db4bf254750c042bf2215febd23a6d3cda2e64896aef79745fbd4b9996488bd3cafb39ce19dbce0fd6e3b6665275638befffe1c9b312b91b5
-  languageName: node
-  linkType: hard
-
 "denque@npm:^2.1.0":
   version: 2.1.0
   resolution: "denque@npm:2.1.0"
@@ -6059,6 +6161,13 @@ __metadata:
   version: 4.0.2
   resolution: "diff@npm:4.0.2"
   checksum: 10c0/81b91f9d39c4eaca068eb0c1eb0e4afbdc5bb2941d197f513dd596b820b956fef43485876226d65d497bebc15666aa2aa82c679e84f65d5f2bfbf14ee46e32c1
+  languageName: node
+  linkType: hard
+
+"diff@npm:^5.1.0":
+  version: 5.2.2
+  resolution: "diff@npm:5.2.2"
+  checksum: 10c0/52da594c54e9033423da26984b1449ae6accd782d5afc4431c9a192a8507ddc83120fe8f925d7220b9da5b5963c7b6f5e46add3660a00cb36df7a13420a09d4b
   languageName: node
   linkType: hard
 
@@ -6218,7 +6327,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"encoding@npm:^0.1.12, encoding@npm:^0.1.13":
+"encoding@npm:^0.1.13":
   version: 0.1.13
   resolution: "encoding@npm:0.1.13"
   dependencies:
@@ -7167,6 +7276,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"fast-diff@npm:1.2.0":
+  version: 1.2.0
+  resolution: "fast-diff@npm:1.2.0"
+  checksum: 10c0/2fbcb23957fb0bc920832a94ba627b860400f9cce45e1594e931dabf62e858369a58c6c2603e2ecc4f7679580f710b5b5b6e698a355a9a9bfcfd93c06c7c4350
+  languageName: node
+  linkType: hard
+
 "fast-json-stable-stringify@npm:^2.0.0, fast-json-stable-stringify@npm:^2.1.0":
   version: 2.1.0
   resolution: "fast-json-stable-stringify@npm:2.1.0"
@@ -7534,22 +7650,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"gauge@npm:^4.0.3":
-  version: 4.0.4
-  resolution: "gauge@npm:4.0.4"
-  dependencies:
-    aproba: "npm:^1.0.3 || ^2.0.0"
-    color-support: "npm:^1.1.3"
-    console-control-strings: "npm:^1.1.0"
-    has-unicode: "npm:^2.0.1"
-    signal-exit: "npm:^3.0.7"
-    string-width: "npm:^4.2.3"
-    strip-ansi: "npm:^6.0.1"
-    wide-align: "npm:^1.1.5"
-  checksum: 10c0/ef10d7981113d69225135f994c9f8c4369d945e64a8fc721d655a3a38421b738c9fe899951721d1b47b73c41fdb5404ac87cc8903b2ecbed95d2800363e7e58c
-  languageName: node
-  linkType: hard
-
 "generator-function@npm:^2.0.0":
   version: 2.0.1
   resolution: "generator-function@npm:2.0.1"
@@ -7575,6 +7675,13 @@ __metadata:
   version: 1.2.0
   resolution: "get-east-asian-width@npm:1.2.0"
   checksum: 10c0/914b1e217cf38436c24b4c60b4c45289e39a45bf9e65ef9fd343c2815a1a02b8a0215aeec8bf9c07c516089004b6e3826332481f40a09529fcadbf6e579f286b
+  languageName: node
+  linkType: hard
+
+"get-func-name@npm:^2.0.1, get-func-name@npm:^2.0.2":
+  version: 2.0.2
+  resolution: "get-func-name@npm:2.0.2"
+  checksum: 10c0/89830fd07623fa73429a711b9daecdb304386d237c71268007f788f113505ef1d4cc2d0b9680e072c5082490aec9df5d7758bf5ac6f1c37062855e8e3dc0b9df
   languageName: node
   linkType: hard
 
@@ -7882,7 +7989,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"glob@npm:^7.1.3, glob@npm:^7.1.4":
+"glob@npm:^7.1.4":
   version: 7.2.3
   resolution: "glob@npm:7.2.3"
   dependencies:
@@ -8082,7 +8189,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"has-unicode@npm:2.0.1, has-unicode@npm:^2.0.1":
+"has-unicode@npm:2.0.1":
   version: 2.0.1
   resolution: "has-unicode@npm:2.0.1"
   checksum: 10c0/ebdb2f4895c26bb08a8a100b62d362e49b2190bcfd84b76bc4be1a3bd4d254ec52d0dd9f2fbcc093fc5eb878b20c52146f9dfd33e2686ed28982187be593b47c
@@ -8377,7 +8484,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"http-cache-semantics@npm:^4.1.0, http-cache-semantics@npm:^4.1.1":
+"http-cache-semantics@npm:^4.1.1":
   version: 4.1.1
   resolution: "http-cache-semantics@npm:4.1.1"
   checksum: 10c0/ce1319b8a382eb3cbb4a37c19f6bfe14e5bb5be3d09079e885e8c513ab2d3cd9214902f8a31c9dc4e37022633ceabfc2d697405deeaf1b8f3552bb4ed996fdfc
@@ -8391,17 +8498,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"http-proxy-agent@npm:^4.0.1":
-  version: 4.0.1
-  resolution: "http-proxy-agent@npm:4.0.1"
-  dependencies:
-    "@tootallnate/once": "npm:1"
-    agent-base: "npm:6"
-    debug: "npm:4"
-  checksum: 10c0/4fa4774d65b5331814b74ac05cefea56854fc0d5989c80b13432c1b0d42a14c9f4342ca3ad9f0359a52e78da12b1744c9f8a28e50042136ea9171675d972a5fd
-  languageName: node
-  linkType: hard
-
 "http-proxy-agent@npm:^7.0.0, http-proxy-agent@npm:^7.0.2":
   version: 7.0.2
   resolution: "http-proxy-agent@npm:7.0.2"
@@ -8409,16 +8505,6 @@ __metadata:
     agent-base: "npm:^7.1.0"
     debug: "npm:^4.3.4"
   checksum: 10c0/4207b06a4580fb85dd6dff521f0abf6db517489e70863dca1a0291daa7f2d3d2d6015a57bd702af068ea5cf9f1f6ff72314f5f5b4228d299c0904135d2aef921
-  languageName: node
-  linkType: hard
-
-"https-proxy-agent@npm:^5.0.0":
-  version: 5.0.1
-  resolution: "https-proxy-agent@npm:5.0.1"
-  dependencies:
-    agent-base: "npm:6"
-    debug: "npm:4"
-  checksum: 10c0/6dd639f03434003577c62b27cafdb864784ef19b2de430d8ae2a1d45e31c4fd60719e5637b44db1a88a046934307da7089e03d6089ec3ddacc1189d8de8897d1
   languageName: node
   linkType: hard
 
@@ -8453,15 +8539,6 @@ __metadata:
   version: 5.0.0
   resolution: "human-signals@npm:5.0.0"
   checksum: 10c0/5a9359073fe17a8b58e5a085e9a39a950366d9f00217c4ff5878bd312e09d80f460536ea6a3f260b5943a01fe55c158d1cea3fc7bee3d0520aeef04f6d915c82
-  languageName: node
-  linkType: hard
-
-"humanize-ms@npm:^1.2.1":
-  version: 1.2.1
-  resolution: "humanize-ms@npm:1.2.1"
-  dependencies:
-    ms: "npm:^2.0.0"
-  checksum: 10c0/f34a2c20161d02303c2807badec2f3b49cbfbbb409abd4f95a07377ae01cfe6b59e3d15ac609cffcd8f2521f0eb37b7e1091acf65da99aa2a4f1ad63c21e7e7a
   languageName: node
   linkType: hard
 
@@ -8593,13 +8670,6 @@ __metadata:
   version: 4.0.0
   resolution: "indent-string@npm:4.0.0"
   checksum: 10c0/1e1904ddb0cb3d6cce7cd09e27a90184908b7a5d5c21b92e232c93579d314f0b83c246ffb035493d0504b1e9147ba2c9b21df0030f48673fba0496ecd698161f
-  languageName: node
-  linkType: hard
-
-"infer-owner@npm:^1.0.4":
-  version: 1.0.4
-  resolution: "infer-owner@npm:1.0.4"
-  checksum: 10c0/a7b241e3149c26e37474e3435779487f42f36883711f198c45794703c7556bc38af224088bd4d1a221a45b8208ae2c2bcf86200383621434d0c099304481c5b9
   languageName: node
   linkType: hard
 
@@ -10321,6 +10391,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"just-extend@npm:^6.2.0":
+  version: 6.2.0
+  resolution: "just-extend@npm:6.2.0"
+  checksum: 10c0/d41cbdb6d85b986d4deaf2144d81d4f7266cd408fc95189d046d63f610c2dc486b141aeb6ef319c2d76fe904d45a6bb31f19b098ff0427c35688e0c383fc0511
+  languageName: node
+  linkType: hard
+
 "keyv@npm:^4.5.4":
   version: 4.5.4
   resolution: "keyv@npm:4.5.4"
@@ -10712,6 +10789,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"loupe@npm:^2.3.6":
+  version: 2.3.7
+  resolution: "loupe@npm:2.3.7"
+  dependencies:
+    get-func-name: "npm:^2.0.1"
+  checksum: 10c0/71a781c8fc21527b99ed1062043f1f2bb30bdaf54fa4cf92463427e1718bc6567af2988300bc243c1f276e4f0876f29e3cbf7b58106fdc186915687456ce5bf4
+  languageName: node
+  linkType: hard
+
 "lru-cache@npm:^10.0.1, lru-cache@npm:^10.2.0":
   version: 10.2.2
   resolution: "lru-cache@npm:10.2.2"
@@ -10730,6 +10816,13 @@ __metadata:
   version: 11.2.4
   resolution: "lru-cache@npm:11.2.4"
   checksum: 10c0/4a24f9b17537619f9144d7b8e42cd5a225efdfd7076ebe7b5e7dc02b860a818455201e67fbf000765233fe7e339d3c8229fc815e9b58ee6ede511e07608c19b2
+  languageName: node
+  linkType: hard
+
+"lru-cache@npm:^11.3.5":
+  version: 11.5.1
+  resolution: "lru-cache@npm:11.5.1"
+  checksum: 10c0/7b341cea79a8efe9c6a6f20c8757a77eca5b25d7ff983ccf4e11e547b81f6787824baa1c84705251dff84ab4ffac85717ac354b9d02e465f86a9f8b166409979
   languageName: node
   linkType: hard
 
@@ -10860,30 +10953,6 @@ __metadata:
     promise-retry: "npm:^2.0.1"
     ssri: "npm:^13.0.0"
   checksum: 10c0/525f74915660be60b616bcbd267c4a5b59481b073ba125e45c9c3a041bb1a47a2bd0ae79d028eb6f5f95bf9851a4158423f5068539c3093621abb64027e8e461
-  languageName: node
-  linkType: hard
-
-"make-fetch-happen@npm:^9.1.0":
-  version: 9.1.0
-  resolution: "make-fetch-happen@npm:9.1.0"
-  dependencies:
-    agentkeepalive: "npm:^4.1.3"
-    cacache: "npm:^15.2.0"
-    http-cache-semantics: "npm:^4.1.0"
-    http-proxy-agent: "npm:^4.0.1"
-    https-proxy-agent: "npm:^5.0.0"
-    is-lambda: "npm:^1.0.1"
-    lru-cache: "npm:^6.0.0"
-    minipass: "npm:^3.1.3"
-    minipass-collect: "npm:^1.0.2"
-    minipass-fetch: "npm:^1.3.2"
-    minipass-flush: "npm:^1.0.5"
-    minipass-pipeline: "npm:^1.2.4"
-    negotiator: "npm:^0.6.2"
-    promise-retry: "npm:^2.0.1"
-    socks-proxy-agent: "npm:^6.0.0"
-    ssri: "npm:^8.0.0"
-  checksum: 10c0/2c737faf6a7f67077679da548b5bfeeef890595bf8c4323a1f76eae355d27ebb33dcf9cf1a673f944cf2f2a7cbf4e2b09f0a0a62931737728f210d902c6be966
   languageName: node
   linkType: hard
 
@@ -11800,36 +11869,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"minipass-collect@npm:^1.0.2":
-  version: 1.0.2
-  resolution: "minipass-collect@npm:1.0.2"
-  dependencies:
-    minipass: "npm:^3.0.0"
-  checksum: 10c0/8f82bd1f3095b24f53a991b04b67f4c710c894e518b813f0864a31de5570441a509be1ca17e0bb92b047591a8fdbeb886f502764fefb00d2f144f4011791e898
-  languageName: node
-  linkType: hard
-
 "minipass-collect@npm:^2.0.1":
   version: 2.0.1
   resolution: "minipass-collect@npm:2.0.1"
   dependencies:
     minipass: "npm:^7.0.3"
   checksum: 10c0/5167e73f62bb74cc5019594709c77e6a742051a647fe9499abf03c71dca75515b7959d67a764bdc4f8b361cf897fbf25e2d9869ee039203ed45240f48b9aa06e
-  languageName: node
-  linkType: hard
-
-"minipass-fetch@npm:^1.3.2":
-  version: 1.4.1
-  resolution: "minipass-fetch@npm:1.4.1"
-  dependencies:
-    encoding: "npm:^0.1.12"
-    minipass: "npm:^3.1.0"
-    minipass-sized: "npm:^1.0.3"
-    minizlib: "npm:^2.0.0"
-  dependenciesMeta:
-    encoding:
-      optional: true
-  checksum: 10c0/a43da7401cd7c4f24b993887d41bd37d097356083b0bb836fd655916467463a1e6e9e553b2da4fcbe8745bf23d40c8b884eab20745562199663b3e9060cd8e7a
   languageName: node
   linkType: hard
 
@@ -11887,7 +11932,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"minipass-pipeline@npm:^1.2.2, minipass-pipeline@npm:^1.2.4":
+"minipass-pipeline@npm:^1.2.4":
   version: 1.2.4
   resolution: "minipass-pipeline@npm:1.2.4"
   dependencies:
@@ -11905,7 +11950,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"minipass@npm:^3.0.0, minipass@npm:^3.1.0, minipass@npm:^3.1.1, minipass@npm:^3.1.3":
+"minipass@npm:^3.0.0":
   version: 3.3.6
   resolution: "minipass@npm:3.3.6"
   dependencies:
@@ -11949,7 +11994,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"minizlib@npm:^2.0.0, minizlib@npm:^2.1.1, minizlib@npm:^2.1.2":
+"minizlib@npm:^2.1.1, minizlib@npm:^2.1.2":
   version: 2.1.2
   resolution: "minizlib@npm:2.1.2"
   dependencies:
@@ -11975,7 +12020,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"mkdirp@npm:^1.0.3, mkdirp@npm:^1.0.4":
+"mkdirp@npm:^1.0.3":
   version: 1.0.4
   resolution: "mkdirp@npm:1.0.4"
   bin:
@@ -12051,6 +12096,50 @@ __metadata:
   languageName: node
   linkType: hard
 
+"mongodb-connection-string-url@npm:^7.0.0":
+  version: 7.0.1
+  resolution: "mongodb-connection-string-url@npm:7.0.1"
+  dependencies:
+    "@types/whatwg-url": "npm:^13.0.0"
+    whatwg-url: "npm:^14.1.0"
+  checksum: 10c0/0124edacc556bfb8d7b63b7fe7a1d9e641120fb614ccd40e656c9a948d308280956d41e375ccee01738e13d0fdccaf6d5a95e81b70f05b901e721fa5a9bebd2c
+  languageName: node
+  linkType: hard
+
+"mongodb@npm:*":
+  version: 7.4.0
+  resolution: "mongodb@npm:7.4.0"
+  dependencies:
+    "@mongodb-js/saslprep": "npm:^1.3.0"
+    bson: "npm:^7.2.0"
+    mongodb-connection-string-url: "npm:^7.0.0"
+  peerDependencies:
+    "@aws-sdk/credential-providers": ^3.806.0
+    "@mongodb-js/zstd": ^7.0.0
+    gcp-metadata: ^7.0.1
+    kerberos: ^7.0.0
+    mongodb-client-encryption: ">=7.0.0 <7.1.0"
+    snappy: ^7.3.2
+    socks: ^2.8.6
+  peerDependenciesMeta:
+    "@aws-sdk/credential-providers":
+      optional: true
+    "@mongodb-js/zstd":
+      optional: true
+    gcp-metadata:
+      optional: true
+    kerberos:
+      optional: true
+    mongodb-client-encryption:
+      optional: true
+    snappy:
+      optional: true
+    socks:
+      optional: true
+  checksum: 10c0/c48bb6ba149d3bab23a0e54b751d7702d00a40cf7374f58c021d3b5f869bdbdc790555a64af7d250e8013c19c4ea6260970c725b67d5dec61912b456bd0dbee0
+  languageName: node
+  linkType: hard
+
 "mongodb@npm:^3.1.13 || ^4.0.0 || ^5.0.0 || ^6.0.0, mongodb@npm:^6.0.0":
   version: 6.6.2
   resolution: "mongodb@npm:6.6.2"
@@ -12092,7 +12181,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ms@npm:^2.0.0, ms@npm:^2.1.1, ms@npm:^2.1.3":
+"ms@npm:^2.1.1, ms@npm:^2.1.3":
   version: 2.1.3
   resolution: "ms@npm:2.1.3"
   checksum: 10c0/d924b57e7312b3b63ad21fc5b3dc0af5e78d61a1fc7cfb5457edaf26326bf62be5307cc87ffb6862ef1c2b33b0233cdb5d4f01c4c958cc0d660948b65a287a48
@@ -12142,7 +12231,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"negotiator@npm:^0.6.2, negotiator@npm:^0.6.3":
+"negotiator@npm:^0.6.3":
   version: 0.6.3
   resolution: "negotiator@npm:0.6.3"
   checksum: 10c0/3ec9fd413e7bf071c937ae60d572bc67155262068ed522cf4b3be5edbe6ddf67d095ec03a3a14ebf8fc8e95f8e1d61be4869db0dbb0de696f6b837358bd43fc2
@@ -12184,6 +12273,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"nise@npm:^5.1.4":
+  version: 5.1.9
+  resolution: "nise@npm:5.1.9"
+  dependencies:
+    "@sinonjs/commons": "npm:^3.0.0"
+    "@sinonjs/fake-timers": "npm:^11.2.2"
+    "@sinonjs/text-encoding": "npm:^0.7.2"
+    just-extend: "npm:^6.2.0"
+    path-to-regexp: "npm:^6.2.1"
+  checksum: 10c0/a44318e6de738b34a1f51b4b478f97f5b40a5a27175be4bf13f6e5b8e67aa70d0b3f51c77a966d6617fccdc3b436c675a89be57424833e6d8a290367faa66b28
+  languageName: node
+  linkType: hard
+
 "node-abi@npm:^3.3.0":
   version: 3.85.0
   resolution: "node-abi@npm:3.85.0"
@@ -12193,32 +12295,32 @@ __metadata:
   languageName: node
   linkType: hard
 
-"node-addon-api@npm:^7.0.0":
-  version: 7.1.1
-  resolution: "node-addon-api@npm:7.1.1"
+"node-addon-api@npm:^8.0.0":
+  version: 8.9.0
+  resolution: "node-addon-api@npm:8.9.0"
   dependencies:
     node-gyp: "npm:latest"
-  checksum: 10c0/fb32a206276d608037fa1bcd7e9921e177fe992fc610d098aa3128baca3c0050fc1e014fa007e9b3874cf865ddb4f5bd9f43ccb7cbbbe4efaff6a83e920b17e9
+  checksum: 10c0/6d687ffbc66e9735f4182e4c05d137d083be1fa5972b1762307e007804a85b70f810fed5b908f27f48caa4ed831517c95eec5137c8a02eaa08893bdef7fec05e
   languageName: node
   linkType: hard
 
-"node-gyp@npm:8.x":
-  version: 8.4.1
-  resolution: "node-gyp@npm:8.4.1"
+"node-gyp@npm:12.x":
+  version: 12.4.0
+  resolution: "node-gyp@npm:12.4.0"
   dependencies:
     env-paths: "npm:^2.2.0"
-    glob: "npm:^7.1.4"
+    exponential-backoff: "npm:^3.1.1"
     graceful-fs: "npm:^4.2.6"
-    make-fetch-happen: "npm:^9.1.0"
-    nopt: "npm:^5.0.0"
-    npmlog: "npm:^6.0.0"
-    rimraf: "npm:^3.0.2"
+    nopt: "npm:^9.0.0"
+    proc-log: "npm:^6.0.0"
     semver: "npm:^7.3.5"
-    tar: "npm:^6.1.2"
-    which: "npm:^2.0.2"
+    tar: "npm:^7.5.4"
+    tinyglobby: "npm:^0.2.12"
+    undici: "npm:^6.25.0"
+    which: "npm:^6.0.0"
   bin:
     node-gyp: bin/node-gyp.js
-  checksum: 10c0/80ef333b3a882eb6a2695a8e08f31d618f4533eff192864e4a3a16b67ff0abc9d8c1d5fac0395550ec699326b9248c5e2b3be178492f7f4d1ccf97d2cf948021
+  checksum: 10c0/9acb7c798e124275a6f9c1f7eb64b5abd6196bb885a3945fb44ee0dccf435514e88cdfb0f228ee7ff76ef25107c1f39ff37a067bf92fd00b9aff9234db29ff9e
   languageName: node
   linkType: hard
 
@@ -12307,17 +12409,6 @@ __metadata:
   version: 2.0.38
   resolution: "node-releases@npm:2.0.38"
   checksum: 10c0/db9909234ed750c5b9d0075f83214cd16b76370b54eab50e3554f3ba939ba7ac39f3aca2ddf93471ae8553dbde2ea9354b0ae380c9cff1f8e53b55e414903413
-  languageName: node
-  linkType: hard
-
-"nopt@npm:^5.0.0":
-  version: 5.0.0
-  resolution: "nopt@npm:5.0.0"
-  dependencies:
-    abbrev: "npm:1"
-  bin:
-    nopt: bin/nopt.js
-  checksum: 10c0/fc5c4f07155cb455bf5fc3dd149fac421c1a40fd83c6bfe83aa82b52f02c17c5e88301321318adaa27611c8a6811423d51d29deaceab5fa158b585a61a551061
   languageName: node
   linkType: hard
 
@@ -12552,18 +12643,6 @@ __metadata:
   dependencies:
     path-key: "npm:^4.0.0"
   checksum: 10c0/124df74820c40c2eb9a8612a254ea1d557ddfab1581c3e751f825e3e366d9f00b0d76a3c94ecd8398e7f3eee193018622677e95816e8491f0797b21e30b2deba
-  languageName: node
-  linkType: hard
-
-"npmlog@npm:^6.0.0":
-  version: 6.0.2
-  resolution: "npmlog@npm:6.0.2"
-  dependencies:
-    are-we-there-yet: "npm:^3.0.0"
-    console-control-strings: "npm:^1.1.0"
-    gauge: "npm:^4.0.3"
-    set-blocking: "npm:^2.0.0"
-  checksum: 10c0/0cacedfbc2f6139c746d9cd4a85f62718435ad0ca4a2d6459cd331dd33ae58206e91a0742c1558634efcde3f33f8e8e7fd3adf1bfe7978310cf00bd55cccf890
   languageName: node
   linkType: hard
 
@@ -12890,6 +12969,24 @@ __metadata:
   version: 1.1.0
   resolution: "ot-json0@npm:1.1.0"
   checksum: 10c0/b553940a90fc0b46f246a832b18cecb37089edd44dd6f6eec84a0753c54c1cf739fe19ef550efa2c0f15f7245eadb3226d7587416315413819512d4c1f7c02b4
+  languageName: node
+  linkType: hard
+
+"ot-json1@npm:^1.0.2":
+  version: 1.0.2
+  resolution: "ot-json1@npm:1.0.2"
+  dependencies:
+    ot-text-unicode: "npm:4"
+  checksum: 10c0/c90767cb27e0c41873f7b0972626fc0f7e8ecf82e74c7dce21dec5e859cfaf2c8642b7e0065ac29abe44e36eb61ff979be723495721768b2ce91f2f6f1bfba22
+  languageName: node
+  linkType: hard
+
+"ot-text-unicode@npm:4":
+  version: 4.0.0
+  resolution: "ot-text-unicode@npm:4.0.0"
+  dependencies:
+    unicount: "npm:1.1"
+  checksum: 10c0/1ed497f6ac3693664aa6dca24e520a161d2b45c8a377bb99959ee60465d7074230e8fcd373b4d9dd988bf7b15bb3c0ef645670caaccd6817c3b2ef5cfe429572
   languageName: node
   linkType: hard
 
@@ -13289,6 +13386,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"path-to-regexp@npm:^6.2.1":
+  version: 6.3.0
+  resolution: "path-to-regexp@npm:6.3.0"
+  checksum: 10c0/73b67f4638b41cde56254e6354e46ae3a2ebc08279583f6af3d96fe4664fc75788f74ed0d18ca44fa4a98491b69434f9eee73b97bb5314bd1b5adb700f5c18d6
+  languageName: node
+  linkType: hard
+
 "path-type@npm:^3.0.0":
   version: 3.0.0
   resolution: "path-type@npm:3.0.0"
@@ -13302,6 +13406,13 @@ __metadata:
   version: 4.0.0
   resolution: "path-type@npm:4.0.0"
   checksum: 10c0/666f6973f332f27581371efaf303fd6c272cc43c2057b37aa99e3643158c7e4b2626549555d88626e99ea9e046f82f32e41bbde5f1508547e9a11b149b52387c
+  languageName: node
+  linkType: hard
+
+"pathval@npm:^1.1.1":
+  version: 1.1.1
+  resolution: "pathval@npm:1.1.1"
+  checksum: 10c0/f63e1bc1b33593cdf094ed6ff5c49c1c0dc5dc20a646ca9725cc7fe7cd9995002d51d5685b9b2ec6814342935748b711bafa840f84c0bb04e38ff40a335c94dc
   languageName: node
   linkType: hard
 
@@ -13442,7 +13553,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"prebuild-install@npm:^7.1.1":
+"prebuild-install@npm:^7.1.3":
   version: 7.1.3
   resolution: "prebuild-install@npm:7.1.3"
   dependencies:
@@ -13579,13 +13690,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"promise-inflight@npm:^1.0.1":
-  version: 1.0.1
-  resolution: "promise-inflight@npm:1.0.1"
-  checksum: 10c0/d179d148d98fbff3d815752fa9a08a87d3190551d1420f17c4467f628214db12235ae068d98cd001f024453676d8985af8f28f002345646c4ece4600a79620bc
-  languageName: node
-  linkType: hard
-
 "promise-retry@npm:^2.0.1":
   version: 2.0.1
   resolution: "promise-retry@npm:2.0.1"
@@ -13672,6 +13776,17 @@ __metadata:
   version: 4.0.1
   resolution: "quick-lru@npm:4.0.1"
   checksum: 10c0/f9b1596fa7595a35c2f9d913ac312fede13d37dc8a747a51557ab36e11ce113bbe88ef4c0154968845559a7709cb6a7e7cbe75f7972182451cd45e7f057a334d
+  languageName: node
+  linkType: hard
+
+"quill-delta@npm:^4.2.1":
+  version: 4.2.2
+  resolution: "quill-delta@npm:4.2.2"
+  dependencies:
+    fast-diff: "npm:1.2.0"
+    lodash.clonedeep: "npm:^4.5.0"
+    lodash.isequal: "npm:^4.5.0"
+  checksum: 10c0/cecd1584c59e360908e642fc159ef931929aecc930af208b79397daf1259df76efc7a12ad5c924171bd9861bfcf80cb20dbe4fcc2468eab5a84a72d0852c15aa
   languageName: node
   linkType: hard
 
@@ -13885,7 +14000,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"readable-stream@npm:^3.0.0, readable-stream@npm:^3.0.2, readable-stream@npm:^3.1.1, readable-stream@npm:^3.4.0, readable-stream@npm:^3.6.0":
+"readable-stream@npm:^3.0.0, readable-stream@npm:^3.0.2, readable-stream@npm:^3.1.1, readable-stream@npm:^3.4.0":
   version: 3.6.2
   resolution: "readable-stream@npm:3.6.2"
   dependencies:
@@ -14346,14 +14461,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"rimraf@npm:^3.0.2":
-  version: 3.0.2
-  resolution: "rimraf@npm:3.0.2"
+"rich-text@npm:^4.1.0":
+  version: 4.1.0
+  resolution: "rich-text@npm:4.1.0"
   dependencies:
-    glob: "npm:^7.1.3"
-  bin:
-    rimraf: bin.js
-  checksum: 10c0/9cb7757acb489bd83757ba1a274ab545eafd75598a9d817e0c3f8b164238dd90eba50d6b848bd4dcc5f3040912e882dc7ba71653e35af660d77b25c381d402e8
+    quill-delta: "npm:^4.2.1"
+  checksum: 10c0/44ab500bad2baffc27432f8bc485a93e1a1db7d67a868c0f7a600a041e58df174005cc320981d3ab975fed0ec55c9f75bccfcab42cf246be6fcfa7dccd821b24
   languageName: node
   linkType: hard
 
@@ -14797,7 +14910,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"signal-exit@npm:3.0.7, signal-exit@npm:^3.0.2, signal-exit@npm:^3.0.3, signal-exit@npm:^3.0.7":
+"signal-exit@npm:3.0.7, signal-exit@npm:^3.0.2, signal-exit@npm:^3.0.3":
   version: 3.0.7
   resolution: "signal-exit@npm:3.0.7"
   checksum: 10c0/25d272fa73e146048565e08f3309d5b942c1979a6f4a58a8c59d5fa299728e9c2fcd1a759ec870863b1fd38653670240cd420dad2ad9330c71f36608a6a1c912
@@ -14840,6 +14953,20 @@ __metadata:
     once: "npm:^1.3.1"
     simple-concat: "npm:^1.0.0"
   checksum: 10c0/b0649a581dbca741babb960423248899203165769747142033479a7dc5e77d7b0fced0253c731cd57cf21e31e4d77c9157c3069f4448d558ebc96cf9e1eebcf0
+  languageName: node
+  linkType: hard
+
+"sinon@npm:^15.2.0":
+  version: 15.2.0
+  resolution: "sinon@npm:15.2.0"
+  dependencies:
+    "@sinonjs/commons": "npm:^3.0.0"
+    "@sinonjs/fake-timers": "npm:^10.3.0"
+    "@sinonjs/samsam": "npm:^8.0.0"
+    diff: "npm:^5.1.0"
+    nise: "npm:^5.1.4"
+    supports-color: "npm:^7.2.0"
+  checksum: 10c0/c5eff6020f3cd7ffaed536fa3cd57428555e30d0f0892414304c7531e7355574d7162e62725b10d0f6bccf6f6e9fd33ecc5a8624080c2b6029a324e209df0f2b
   languageName: node
   linkType: hard
 
@@ -14890,17 +15017,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"socks-proxy-agent@npm:^6.0.0":
-  version: 6.2.1
-  resolution: "socks-proxy-agent@npm:6.2.1"
-  dependencies:
-    agent-base: "npm:^6.0.2"
-    debug: "npm:^4.3.3"
-    socks: "npm:^2.6.2"
-  checksum: 10c0/d75c1cf1fdd7f8309a43a77f84409b793fc0f540742ef915154e70ac09a08b0490576fe85d4f8d68bbf80e604a62957a17ab5ef50d312fe1442b0ab6f8f6e6f6
-  languageName: node
-  linkType: hard
-
 "socks-proxy-agent@npm:^8.0.3":
   version: 8.0.3
   resolution: "socks-proxy-agent@npm:8.0.3"
@@ -14912,7 +15028,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"socks@npm:^2.6.2, socks@npm:^2.7.1":
+"socks@npm:^2.7.1":
   version: 2.8.3
   resolution: "socks@npm:2.8.3"
   dependencies:
@@ -15037,24 +15153,24 @@ __metadata:
   languageName: node
   linkType: hard
 
-"sqlite3@npm:^5.1.6":
-  version: 5.1.7
-  resolution: "sqlite3@npm:5.1.7"
+"sqlite3@npm:^6.0.1":
+  version: 6.0.1
+  resolution: "sqlite3@npm:6.0.1"
   dependencies:
     bindings: "npm:^1.5.0"
-    node-addon-api: "npm:^7.0.0"
-    node-gyp: "npm:8.x"
-    prebuild-install: "npm:^7.1.1"
-    tar: "npm:^6.1.11"
+    node-addon-api: "npm:^8.0.0"
+    node-gyp: "npm:12.x"
+    prebuild-install: "npm:^7.1.3"
+    tar: "npm:^7.5.10"
   peerDependencies:
-    node-gyp: 8.x
+    node-gyp: 12.x
   dependenciesMeta:
     node-gyp:
       optional: true
   peerDependenciesMeta:
     node-gyp:
       optional: true
-  checksum: 10c0/10daab5d7854bd0ec3c7690c00359cd3444eabc869b68c68dcb61374a8fa5e2f4be06cf0aba78f7a16336d49e83e4631e8af98f8bd33c772fe8d60b45fa60bc1
+  checksum: 10c0/519e1b84168e4404872d68b5261d73326dd6551bbf2a6b9d6318f3193efe5392ee2c1061a10e18f3d7dcbe6dc4c753513e3f83986d3bca703f363545eba2fb8e
   languageName: node
   linkType: hard
 
@@ -15082,15 +15198,6 @@ __metadata:
   dependencies:
     minipass: "npm:^7.0.3"
   checksum: 10c0/405f3a531cd98b013cecb355d63555dca42fd12c7bc6671738aaa9a82882ff41cdf0ef9a2b734ca4f9a760338f114c29d01d9238a65db3ccac27929bd6e6d4b2
-  languageName: node
-  linkType: hard
-
-"ssri@npm:^8.0.0, ssri@npm:^8.0.1":
-  version: 8.0.1
-  resolution: "ssri@npm:8.0.1"
-  dependencies:
-    minipass: "npm:^3.1.1"
-  checksum: 10c0/5cfae216ae02dcd154d1bbed2d0a60038a4b3a2fcaac3c7e47401ff4e058e551ee74cfdba618871bf168cd583db7b8324f94af6747d4303b73cd4c3f6dc5c9c2
   languageName: node
   linkType: hard
 
@@ -15413,7 +15520,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"supports-color@npm:^7.1.0":
+"supports-color@npm:^7.1.0, supports-color@npm:^7.2.0":
   version: 7.2.0
   resolution: "supports-color@npm:7.2.0"
   dependencies:
@@ -15486,7 +15593,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tar@npm:6.2.1, tar@npm:^6.0.2, tar@npm:^6.1.11, tar@npm:^6.1.2":
+"tar@npm:6.2.1, tar@npm:^6.1.11, tar@npm:^6.1.2":
   version: 6.2.1
   resolution: "tar@npm:6.2.1"
   dependencies:
@@ -15510,6 +15617,19 @@ __metadata:
     minizlib: "npm:^3.1.0"
     yallist: "npm:^5.0.0"
   checksum: 10c0/a7d8b801139b52f93a7e34830db0de54c5aa45487c7cb551f6f3d44a112c67f1cb8ffdae856b05fd4f17b1749911f1c26f1e3a23bbe0279e17fd96077f13f467
+  languageName: node
+  linkType: hard
+
+"tar@npm:^7.5.10, tar@npm:^7.5.4":
+  version: 7.5.19
+  resolution: "tar@npm:7.5.19"
+  dependencies:
+    "@isaacs/fs-minipass": "npm:^4.0.0"
+    chownr: "npm:^3.0.0"
+    minipass: "npm:^7.1.2"
+    minizlib: "npm:^3.1.0"
+    yallist: "npm:^5.0.0"
+  checksum: 10c0/7022e8cb04a8ceccc0689f2c731743fa2aab2e3c3f559f7dbc37b65ef7d5913049b427284eded2ec0765c5db5ff72dd7939fe2ae15785ff422cef2116c95d798
   languageName: node
   linkType: hard
 
@@ -15885,6 +16005,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"type-detect@npm:^4.0.0, type-detect@npm:^4.1.0":
+  version: 4.1.0
+  resolution: "type-detect@npm:4.1.0"
+  checksum: 10c0/df8157ca3f5d311edc22885abc134e18ff8ffbc93d6a9848af5b682730ca6a5a44499259750197250479c5331a8a75b5537529df5ec410622041650a7f293e2a
+  languageName: node
+  linkType: hard
+
 "type-fest@npm:^0.18.0":
   version: 0.18.1
   resolution: "type-fest@npm:0.18.1"
@@ -16141,6 +16268,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"undici@npm:^6.25.0":
+  version: 6.27.0
+  resolution: "undici@npm:6.27.0"
+  checksum: 10c0/f88c3dae3957dbf9d93cb481440aced317bd3c4941b5914fea5efba516d51138988cdb5c76006f0bb1337e41d56c3443351055d492e73af2428521c37ba2a76f
+  languageName: node
+  linkType: hard
+
 "unhead@npm:2.1.2":
   version: 2.1.2
   resolution: "unhead@npm:2.1.2"
@@ -16157,6 +16291,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"unicount@npm:1.1":
+  version: 1.1.0
+  resolution: "unicount@npm:1.1.0"
+  checksum: 10c0/fb1ab7eee275fa16dc3b6cc5aade84a12b776220a64a366e2b78d9fa41d87f0990f852db66b4592a5c64f6a2b458ef65e0459bd2540f4c1e8f9b91f3f20d0866
+  languageName: node
+  linkType: hard
+
 "unified@npm:^11.0.0, unified@npm:^11.0.5":
   version: 11.0.5
   resolution: "unified@npm:11.0.5"
@@ -16169,15 +16310,6 @@ __metadata:
     trough: "npm:^2.0.0"
     vfile: "npm:^6.0.0"
   checksum: 10c0/53c8e685f56d11d9d458a43e0e74328a4d6386af51c8ac37a3dcabec74ce5026da21250590d4aff6733ccd7dc203116aae2b0769abc18cdf9639a54ae528dfc9
-  languageName: node
-  linkType: hard
-
-"unique-filename@npm:^1.1.1":
-  version: 1.1.1
-  resolution: "unique-filename@npm:1.1.1"
-  dependencies:
-    unique-slug: "npm:^2.0.0"
-  checksum: 10c0/d005bdfaae6894da8407c4de2b52f38b3c58ec86e79fc2ee19939da3085374413b073478ec54e721dc8e32b102cf9e50d0481b8331abdc62202e774b789ea874
   languageName: node
   linkType: hard
 
@@ -16205,15 +16337,6 @@ __metadata:
   dependencies:
     unique-slug: "npm:^6.0.0"
   checksum: 10c0/afb897e9cf4c2fb622ea716f7c2bb462001928fc5f437972213afdf1cc32101a230c0f1e9d96fc91ee5185eca0f2feb34127145874975f347be52eb91d6ccc2c
-  languageName: node
-  linkType: hard
-
-"unique-slug@npm:^2.0.0":
-  version: 2.0.2
-  resolution: "unique-slug@npm:2.0.2"
-  dependencies:
-    imurmurhash: "npm:^0.1.4"
-  checksum: 10c0/9eabc51680cf0b8b197811a48857e41f1364b25362300c1ff636c0eca5ec543a92a38786f59cf0697e62c6f814b11ecbe64e8093db71246468a1f03b80c83970
   languageName: node
   linkType: hard
 
@@ -16472,6 +16595,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"uuid@npm:^14.0.0":
+  version: 14.0.1
+  resolution: "uuid@npm:14.0.1"
+  bin:
+    uuid: dist-node/bin/uuid
+  checksum: 10c0/2d961289097cb68c37d93d1da0b5c3aafc1eb9948a455cca8d0ae53a099b2fe583b8933254a84097f700e6bac2e23033364904df0467c22551d5d9611febcaf6
+  languageName: node
+  linkType: hard
+
 "uuid@npm:^3.4.0":
   version: 3.4.0
   resolution: "uuid@npm:3.4.0"
@@ -16663,7 +16795,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"whatwg-url@npm:^14.0.0, whatwg-url@npm:^14.1.1":
+"whatwg-url@npm:^14.0.0, whatwg-url@npm:^14.1.0, whatwg-url@npm:^14.1.1":
   version: 14.2.0
   resolution: "whatwg-url@npm:14.2.0"
   dependencies:
@@ -16767,7 +16899,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"which@npm:^2.0.1, which@npm:^2.0.2":
+"which@npm:^2.0.1":
   version: 2.0.2
   resolution: "which@npm:2.0.2"
   dependencies:
@@ -16811,7 +16943,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"wide-align@npm:1.1.5, wide-align@npm:^1.1.5":
+"wide-align@npm:1.1.5":
   version: 1.1.5
   resolution: "wide-align@npm:1.1.5"
   dependencies:


### PR DESCRIPTION
## What

A new **opt-in** ShareDB database adapter backed by [Pongo](https://github.com/event-driven-io/Pongo) (`@event-driven-io/pongo@0.17.0-beta.39`, the latest beta with SQLite support) that runs mongo-style queries **as SQL directly over the SQLite file**, selected with `DB_ADAPTER=pongo-sqlite`. The default stays `mingo-sqlite` — nothing changes unless the env var is set.

## Why

The mingo adapter loads the **whole database into RAM at boot** and serves everything from memory (SQLite is only a write-through log). Process RSS therefore scales with DB size. Measured on the startupjs-ai CMS (production build, same machine, same seeded data):

| | empty DB | 62 MB DB |
|---|---|---|
| mingo-sqlite | 5.2s boot / 163 MB RSS | 5.3s / **375 MB** |
| pongo-sqlite | 5.2s boot / 166 MB RSS | 5.3s / **168 MB** |

mingo pays ~3.4× the DB file size in resident memory; pongo pays ~nothing.

## Design

- **Storage** (managed by Pongo, fresh format — no migration from mingo-format files):
  - `<collection>` — snapshot docs `{ _id, v, type, data, m, alive }`. Tombstones of deleted docs are kept (same as sharedb-mongo/mingo) so recreated docs continue version numbering; `alive: 1|0` mirrors `type != null` because SQL can't test JSON null/missing. Collections named `files`/`sessions` remap to `<name>__docs` (those raw table names belong to the express session store and upload blobs sharing the file).
  - `<collection>__ops` — op docs with deterministic `'<docId>.<v>'` primary keys: `getOps` is pure PK lookups (no scans, chunked under the bound-param limit) and op writes are idempotent.
- **Commit concurrency**: conditional write as the version arbiter — insert (PK-unique) for v=1, `replaceOne({_id, v: snapshot.v - 1})` otherwise; SQLite serializes writers so exactly one concurrent commit per doc version wins, and only the winner writes its op.
- **Queries are two-tier**:
  1. SQL fast path for filters/sorts Pongo can translate (equality incl. array-contains, `$gt/$gte/$lt/$lte`, `$in`, sorts/skip/limit/`$count`).
  2. JS fallback for everything else (`$or`, `$ne`/`$nin` (match missing fields in mongo), null equality, regex, `$exists`, exact array/subdoc equality, `$aggregate` incl. `$lookup` via prefetch): fetches the collection's live docs and runs the **exact mingo pipeline** the mingo adapter runs (`castToSnapshotQuery` + `Mingo.Query`/`Aggregator`), so semantics always match. The translator is deliberately conservative — anything with even slightly different SQL semantics falls back.
- **Lifecycle**: `close()` drains in-flight operations (a commit interrupted mid-sequence by pool shutdown would surface as spurious client errors); each collection's first op is gated behind an awaited `CREATE TABLE` (pongo clears its auto-migration flag before the CREATE completes, which races concurrent first ops).
- **Boot**: same 24h ops TTL prune as mingo-sqlite (keeps each doc's latest op); WAL + busy_timeout on all connections; keeps the raw `sqlite` export (sessions/files consumers) on the same file. `DB_LOAD_SNAPSHOT` copies the whole file (pongo format differs from mingo tables).
- `sqlite3` bumped to `^6.0.1` (pongo's peer dep; the mingo adapter API usage is unchanged and the full CMS suite passes on it).

## Not supported

- Migration from mingo-format SQLite files (fresh DBs only for now).
- `$lookup` inside `$aggregate` works via prefetch; other cross-collection pipeline features don't.

## Tests

`cd packages/backend && yarn test` — **376 passing**:
- the full **sharedb DB conformance suite** (`sharedb/test/db`) incl. client submit/subscribe/query-subscribe/projections — the same suite `@startupjs/sharedb-mingo-memory` runs
- a **differential battery**: 31 queries spanning both tiers run against mingo AND pongo adapters seeded identically, requiring identical ids, order, snapshot contents, and extras, plus `queryPollDoc` parity
- pongo-specific tests: restart persistence, tombstone version continuity, stale-commit refusal, `files` collection remap

Also validated against the **startupjs-ai CMS** with the adapter overlaid + `DB_ADAPTER=pongo-sqlite`: main E2E 27/27, auth 9/9. (Boutique fixture replay fails identically on master's default adapter — pre-existing, unrelated.)