### PR TITLE
Keep direct document transport alive during GC grace

### DIFF
--- a/architecture.md
+++ b/architecture.md
@@ -340,6 +340,16 @@ sub($.users[id])
 
 [packages/teamplay/src/orm/Doc.js](./packages/teamplay/src/orm/Doc.js) manages the ShareDB doc lifecycle. It tracks subscription/fetch mode, mirrors load/create/delete/op events into observable state, injects id fields into plain objects, and delays cleanup so short-lived UI ownership changes do not churn transport state.
 
+The cleanup grace has transport-specific semantics:
+
+- an already-live direct document keeps its runtime, materialized data, and
+  ShareDB subscription through `subscriptionGcDelay`; a matching owner can
+  adopt all three without a wire unsubscribe/resubscribe cycle;
+- a direct fetch keeps only its runtime and materialized data through the grace;
+  its transport is unfetched eagerly, and a later owner performs a fresh fetch;
+- forced cleanup (`clear()`, root disposal, explicit destroy, or finalization)
+  bypasses the grace and closes the transport immediately.
+
 ### Query Subscription Flow
 
 ```txt
@@ -363,6 +373,10 @@ $queries.<hash>.extra
 
 Array readers on query signals map query ids back to document signals. This keeps query items behaving like document model signals instead of anonymous plain objects.
 
+Query GC does not share the direct-live transport grace. Its runtime/private
+materialization may remain until delayed cleanup, but the ShareDB query
+transport closes as soon as its final owner leaves.
+
 ### Aggregation Subscription Flow
 
 Aggregations reuse the query transport layer but materialize data under `$aggregations`:
@@ -378,6 +392,9 @@ sub(aggregationHeader, params)
 ```
 
 [packages/teamplay/src/orm/Aggregation.js](./packages/teamplay/src/orm/Aggregation.js) extends query behavior. Aggregation output comes from query `extra`, not from normal query `results`. If aggregation rows include `_id` or `id`, the runtime can inject configured id fields and route model method calls back to source documents.
+
+Aggregations reuse query transport teardown semantics: materialized runtime
+state may wait for GC, while the server aggregation transport closes eagerly.
 
 ## Writes And Mutations
 

--- a/docs/direct-doc-transport-grace-plan.md
+++ b/docs/direct-doc-transport-grace-plan.md
@@ -1,0 +1,457 @@
+# Direct Document Transport Grace: Technical Plan
+
+Status: implementation complete; downstream production integration pending
+
+Target package: `packages/teamplay`
+
+Baseline: `teamplay@0.5.1`, commit `805b885`
+
+## Implementation Log
+
+### 2026-08-01: Characterization and focused GREEN
+
+The focused RED command was:
+
+```sh
+cd packages/teamplay
+npm run test-server -- --grep "Direct document transport grace"
+```
+
+On the unmodified `0.5.1` runtime, the three characterization tests produced
+two expected failures and one pass:
+
+- final-owner removal changed active mode from `subscribe` to `idle` during
+  the grace;
+- quick adoption emitted `subscribe -> unsubscribe -> subscribe` instead of
+  preserving the live transport;
+- final expiry already performed one complete teardown.
+
+The minimal runtime change adds a private target-mode calculation to
+`DocSubscriptions` and uses it only in direct-document reconciliation. The
+owner-derived desired mode remains unchanged.
+
+Focused implementation coverage is GREEN for:
+
+- live retention, adoption, and expiry;
+- zero-delay compatibility;
+- eager fetch and mixed live/fetch transitions;
+- subscribe/teardown races, pending operations, force/root cleanup, and an
+  unsubscribe failure retry;
+- same-hash churn and bounded cleanup of abandoned unique hashes;
+- explicit eager query and aggregation transport contracts;
+- the public `sub()` / `unsub()` path with a real test ShareDB document.
+
+### 2026-08-01: Retain handoff audit
+
+A post-GREEN review found a separate ownership edge: a query could call
+`docSubscriptions.retain()` while an ownerless live document was in grace.
+`retain()` canceled pending destruction but did not reconcile transport mode,
+which would let a query-retained document keep the direct live wire
+indefinitely.
+
+A new RED test reproduced active mode `subscribe` after the retain handoff.
+The fix keeps `cancelDestroy()`'s public `void` contract and has `retain()`
+reconcile only when it canceled a pending destroy. The test is now GREEN:
+query retain keeps runtime/data but closes direct live transport eagerly.
+
+### 2026-08-01: Validation results
+
+| Check | Result |
+| --- | --- |
+| Focused direct grace and non-goal tests | 18 passing |
+| Related retain/GC/grace tests | 31 passing |
+| Full TeamPlay server suite | 444 passing, 4 pending |
+| TeamPlay client suite | 4 suites, 103 tests passing |
+| Internal type tests | passing |
+| External-consumer type tests | passing |
+| Babel plugin suite | 30 passing |
+| Root lint | passing |
+| Root build | passing |
+
+The combined `yarn test` command is not consistently green because of a
+pre-existing order/GC-dependent query assertion in `root finalization`:
+`rootCloseQueries` exposes `null` through the runtime view while the assertion
+expects `undefined`. The same failure was reproduced on a clean detached
+`origin/master` worktree (`419 passing`, `4 pending`, one identical failure),
+and the affected isolated root suites pass (`19 passing`). One standalone full
+server run on this branch passed all 444 tests; the combined run later hit the
+same baseline query failure after all new direct-grace tests passed.
+
+### 2026-08-01: Downstream LMS boundary
+
+A local LMS smoke temporarily replaced only the installed
+`teamplay/dist/orm/Doc.js` with this branch's built output and started the
+player-bundle branch on port 8082. The current LMS branch serves preserved
+production HTML whose hashed script files belong to an earlier static export;
+the new dev server therefore returned HTML for those script URLs and Chromium
+rejected them by MIME type before app JavaScript ran. This does not validate or
+invalidate TeamPlay runtime behavior. The temporary dependency was restored by
+SHA and the LMS worktree remains clean.
+
+The downstream route trace must be repeated after the TeamPlay package is
+integrated and a fresh LMS production player artifact is exported.
+
+TeamPlay implementation and package-level validation are complete. Fresh LMS
+production export, route trace, and product smoke remain pending.
+
+## 1. Problem
+
+TeamPlay already keeps a direct-document runtime and its materialized data for
+`subscriptionGcDelay` after the last owner leaves. The default delay is 3,000
+ms. The live ShareDB transport does not receive the same grace:
+
+1. `DocSubscriptions.unsubscribe()` removes the final owner.
+2. It schedules delayed runtime destruction.
+3. It immediately calls `reconcileTransport()`.
+4. With no owners, `getDesiredTransportMode()` returns `idle` and the ShareDB
+   document is unsubscribed immediately.
+5. A new owner arriving inside the GC window reuses the runtime and data, but
+   must open a new wire subscription and pay another round trip.
+
+The LearnActive direct-stage experiment showed this exact handoff pattern:
+
+- eight repeated direct-document subscriptions were removed;
+- a 160 ms WebSocket RTT scenario improved from 3,794 ms to 3,096 ms;
+- the measured gain was 698 ms (18.4%);
+- the result matched a manual retain upper bound within 2 ms.
+
+The intended change is to keep an already-live direct document subscribed
+during the existing GC window. A new owner can adopt that transport. If no
+owner arrives, the existing destroy path closes and destroys it at the normal
+deadline.
+
+## 2. Scope
+
+### Included
+
+- Direct public document transports managed by `DocSubscriptions`.
+- Only an already-active `subscribe` transport.
+- The existing `subscriptionGcDelay` as the grace duration.
+- Existing explicit cleanup paths: timer expiry, `flushPendingDestroys()`,
+  `clear()`, root disposal, forced destruction, and finalization.
+- Lifecycle, race, cleanup, and bounded-retention tests.
+
+### Excluded
+
+- Query transports.
+- Aggregation transports.
+- `fetch` and fetch-only-root transports.
+- New public configuration or API.
+- LMS route-specific retain/handoff code.
+- A TeamPlay package release or LMS dependency bump in the implementation PR.
+
+Queries can retain large result sets and a live backend query. Aggregations use
+the same query transport machinery and may also retain server computation.
+Their pending-destroy accounting is owner-scoped, unlike the single
+transport-scoped document timer. They need a separate measured load experiment
+before any grace is introduced.
+
+Fetch transports are also excluded. Reusing a completed fetch without issuing
+a new fetch can return stale data because it has no live update stream.
+
+## 3. Required Invariants
+
+1. A direct live document with no owners and a pending GC destroy remains in
+   `subscribe` mode until adoption or cleanup.
+2. A matching live owner arriving before cleanup reuses the same runtime and
+   wire subscription without `unsubscribe -> subscribe` churn.
+3. The grace applies only when the owner count is zero. Normal multi-owner
+   mode reconciliation remains unchanged.
+4. A fetch-only owner is unfetched eagerly and must fetch again when it returns.
+5. A live-to-fetch or fetch-to-live owner transition reconciles immediately;
+   grace must never preserve the wrong transport mode.
+6. Timer expiry closes the transport exactly once, waits for pending document
+   operations, destroys the ShareDB document, disposes data, and removes all
+   manager bookkeeping.
+7. `subscriptionGcDelay = 0` preserves current eager teardown behavior.
+8. Force paths never wait for grace: `clear()`, root disposal, explicit
+   `destroy()`, and forced finalizer cleanup close immediately.
+9. A failed transport transition must not create an unhandled rejection,
+   duplicate timer, detached runtime, or untracked live subscription.
+10. Query and aggregation transport behavior remains unchanged.
+
+## 4. Proposed Runtime Design
+
+Keep owner-derived intent separate from temporary transport retention.
+
+Add a private `DocSubscriptions` helper with semantics similar to:
+
+```js
+getTargetTransportMode (hash) {
+  const desiredMode = this.getDesiredTransportMode(hash)
+  if (desiredMode !== 'idle') return desiredMode
+
+  const entry = this.entries.get(hash)
+  const activeMode = entry?.runtime?.activeTransportMode ?? entry?.mode
+  const canReuseLiveTransport =
+    entry?.pendingDestroy &&
+    this.getEntryTotalCount(entry) === 0 &&
+    activeMode === 'subscribe'
+
+  return canReuseLiveTransport ? 'subscribe' : 'idle'
+}
+```
+
+`reconcileTransport()` and every loop iteration in
+`reconcileTransportNow()` should use the target mode. Owner calculations in
+`getDesiredTransportMode()` remain unchanged.
+
+This design uses the existing lifecycle ordering:
+
+- final owner removal schedules `pendingDestroy` before reconciliation;
+- a new owner calls `cancelDestroy()` before reconciliation;
+- timer expiry and `flushPendingDestroys()` remove `pendingDestroy` before
+  calling `destroyByHash()`;
+- without `pendingDestroy`, the target becomes `idle` and normal teardown runs;
+- force paths either remove the timer or never create it, so they remain eager.
+
+No new entry field or public type is expected. If implementation reveals that
+the temporary mode cannot be derived safely, stop and introduce an explicit
+internal entry field instead of encoding the state in unrelated counters.
+
+## 5. TDD Execution Plan
+
+All behavioral changes start as failing tests. Use a long test GC delay and
+`flushPendingDestroys()` to advance the lifecycle deterministically instead of
+waiting for real timers.
+
+### Phase A: Characterize the missing live grace
+
+File: `packages/teamplay/test/subscriptionManagers.js`
+
+Add a focused `Direct document transport grace` describe block.
+
+1. **RED: final live owner keeps transport active during grace**
+   - Subscribe a `MockDoc` in live mode.
+   - Start the final unsubscribe without awaiting its delayed cleanup promise.
+   - Assert one pending destroy, zero owners, the same runtime, active mode
+     `subscribe`, and no `unsubscribe:subscribe` event.
+   - Current `0.5.1` must fail on the active mode/event assertions.
+
+2. **RED: quick live resubscribe adopts the transport**
+   - Subscribe owner A, start its final unsubscribe, then subscribe owner B to
+     the same hash before flushing cleanup.
+   - Assert the first unsubscribe promise settles after adoption.
+   - Assert the runtime identity is unchanged.
+   - Assert the complete event sequence is only `subscribe:subscribe`.
+   - Assert the canceled timer cannot destroy owner B later.
+
+3. **RED: grace expiry performs one complete teardown**
+   - Start final unsubscribe and call `flushPendingDestroys()`.
+   - Assert exactly one `unsubscribe:subscribe`, one destroy, one dispose, and
+     empty runtime/owner/timer maps.
+   - Await the original unsubscribe promise to prove timer settlement is wired
+     correctly.
+
+Run only this describe block and record the expected RED failures before
+changing runtime code.
+
+### Phase B: Minimal green implementation
+
+File: `packages/teamplay/src/orm/Doc.js`
+
+1. Add the private target-mode helper described above.
+2. Use it only inside document transport reconciliation.
+3. Do not touch `Query.js`, `Aggregation.js`, React hooks, or public exports.
+4. Run the Phase A tests after each source change.
+5. Refactor naming only after all three tests are green.
+
+### Phase C: Mode and configuration boundaries
+
+File: `packages/teamplay/test/subscriptionManagers.js`
+
+Add tests one at a time, RED then GREEN:
+
+1. **Zero-delay compatibility**
+   - With `subscriptionGcDelay = 0`, final live unsubscribe immediately emits
+     `unsubscribe:subscribe` and removes the runtime.
+
+2. **Fetch remains eager**
+   - A fetch-only direct document emits `unsubscribe:fetch` before runtime GC.
+   - A quick new fetch emits a second `subscribe:fetch`; it must not reuse a
+     potentially stale completed fetch.
+
+3. **Live-to-fetch handoff**
+   - While a live transport is in grace, a fetch-only owner arrives.
+   - Assert immediate `unsubscribe:subscribe -> subscribe:fetch` transition and
+     no retained live transport.
+
+4. **Mixed live/fetch owners**
+   - With both owners active, removing the live owner immediately downgrades to
+     fetch because a real fetch owner remains.
+   - Grace starts only after the final fetch owner leaves, and fetch remains
+     eager.
+
+These tests prevent the optimization from changing freshness or transport-mode
+semantics.
+
+### Phase D: Races and hard cleanup
+
+Files:
+
+- `packages/teamplay/test/subscriptionManagers.js`
+- `packages/teamplay/test/rootClose.js`
+- `packages/teamplay/test/gcCleanup.js` only if the manager tests do not cover a
+  real FinalizationRegistry edge.
+
+Add the following tests incrementally:
+
+1. **Unsubscribe while subscribe is in flight**
+   - Use a gated mock subscription.
+   - Remove the owner before the subscribe callback resolves.
+   - After resolution, keep the completed live transport through grace.
+   - On adoption, assert no redundant wire cycle.
+   - Without adoption, flush and assert exactly one teardown.
+
+2. **Resubscribe while teardown is in flight**
+   - Gate the mock unsubscribe.
+   - Add a new owner while teardown is transitioning.
+   - Assert the state machine ends live with one necessary resubscribe and no
+     detached runtime or stale target mode.
+
+3. **Pending document operations**
+   - Keep the existing behavior: grace can expire, but runtime destruction
+     waits for `whenNothingPending()`.
+   - Assert the wire closes once and final destruction happens after pending
+     operations settle.
+
+4. **Clear during grace**
+   - `clear()` cancels the timer, closes immediately, settles the outstanding
+     unsubscribe promise, and leaves no late timer effects.
+
+5. **Root close during grace**
+   - `releaseRootOwnedSubscriptions()` / `closeSignal()` force immediate cleanup
+     when the closing root was the last owner.
+   - When another root owns the same document, closing one root must keep the
+     shared live transport.
+
+6. **Finalizer and explicit force destroy**
+   - Forced cleanup must bypass grace and stay idempotent when another cleanup
+     path races it.
+
+7. **Unsubscribe failure**
+   - A transport failure at grace expiry is observable by an explicitly
+     awaited unsubscribe.
+   - The runtime remains tracked and can be cleaned by a later retry/clear.
+   - No unhandled rejection or duplicate pending timer remains.
+
+After every test, run `assertDocSubscriptionsConsistent(manager)`.
+
+### Phase E: Public-path and non-goal contracts
+
+Files:
+
+- `packages/teamplay/test/sub$.js`
+- `packages/teamplay/test/subscriptionManagers.js`
+
+1. Add one real ShareDB/public API test using `sub()` and `unsub()`:
+   - subscribe a direct live document;
+   - begin `unsub()`;
+   - verify the ShareDB document remains subscribed during grace;
+   - call `sub()` again for the same document;
+   - verify the runtime and wire subscription are reused;
+   - flush final cleanup and verify the ShareDB document is unsubscribed.
+
+2. Strengthen existing query GC tests:
+   - query runtime may remain until GC, but query transport closes immediately;
+   - aggregation transport follows the same eager rule.
+
+3. Add a bounded-retention stress test with mock docs:
+   - churn one hash repeatedly inside grace and assert one runtime, one timer at
+     most, and one initial wire subscribe;
+   - abandon many unique hashes and assert `flushPendingDestroys()` returns all
+     maps and active transports to zero.
+
+## 6. Documentation Changes During Implementation
+
+Update `architecture.md` to state the exact distinction:
+
+- direct live document: runtime, data, and live transport share the GC grace;
+- direct fetch: runtime/data grace only, transport is eager;
+- query/aggregation: runtime materialization grace only, transport is eager.
+
+Update `tasks.md` when implementation starts and move the item to the completed
+summary only after all acceptance checks pass.
+
+No public API documentation is required unless implementation introduces a new
+configuration option. The preferred implementation does not.
+
+## 7. Verification Ladder
+
+Run in this order, stopping at the first unexplained regression:
+
+1. Focused RED/GREEN Mocha tests:
+
+   ```sh
+   cd packages/teamplay
+   npm run test-server -- --grep "Direct document transport grace"
+   ```
+
+2. Related lifecycle suites:
+
+   ```sh
+   cd packages/teamplay
+   npm run test-server -- --grep "Subscription GC grace delay|DocSubscriptions|root-owned direct|GC during in-flight"
+   ```
+
+3. Full TeamPlay server tests:
+
+   ```sh
+   cd packages/teamplay
+   npm run test-server
+   ```
+
+4. Client, type, build, and lint checks:
+
+   ```sh
+   cd packages/teamplay
+   npm run test-client
+   npm run test-types
+   npm run test-types:external
+   cd ../..
+   yarn lint
+   yarn build
+   ```
+
+5. Full monorepo gate:
+
+   ```sh
+   yarn test
+   ```
+
+6. Downstream LMS verification after a local package/link or published patch:
+   - repeat the direct NegoBot route trace at 160 ms WebSocket RTT;
+   - require the eight duplicate phases to remain absent;
+   - smoke Survey + `StudentUploadFile`, direct course, auth, redirect, denied
+     access, stage-to-stage navigation, and root/session teardown;
+   - compare active server subscriptions after navigation and after the 3-second
+     grace to detect retention leaks.
+
+## 8. Acceptance Criteria
+
+The implementation PR is ready for review only when all of the following hold:
+
+- the characterization test is demonstrably RED on `0.5.1` and GREEN with the
+  patch;
+- quick direct-live handoff produces no wire unsubscribe/resubscribe pair;
+- final cleanup occurs once and leaves no active transport, runtime, owner,
+  timer, or data entry;
+- fetch, query, and aggregation transports retain their eager behavior;
+- force cleanup and root isolation remain correct;
+- race and pending-operation tests pass without sleeps tied to production
+  timing;
+- full TeamPlay tests, types, lint, and build pass;
+- downstream LMS reproduces the subscription-phase reduction without new page
+  or console errors.
+
+## 9. Stop Conditions
+
+Stop and redesign instead of widening the patch if any of these occur:
+
+- grace requires changing query or aggregation ownership bookkeeping;
+- a completed fetch would be reused without a new fetch;
+- forced root cleanup must wait for the GC deadline;
+- target-mode derivation cannot distinguish a real owner from temporary grace;
+- server subscription count does not return to baseline after deadline;
+- the downstream trace does not remove the measured duplicate direct-document
+  subscriptions.

--- a/packages/teamplay/src/orm/Doc.js
+++ b/packages/teamplay/src/orm/Doc.js
@@ -405,10 +405,12 @@ export class DocSubscriptions {
     const segments = [...$doc[SEGMENTS]]
     const hash = hashDoc(segments)
     const entry = this.getOrCreateEntry(hash, segments)
+    const hadPendingDestroy = !!entry.pendingDestroy
     this.cancelDestroy(hash)
     entry.retainCount += 1
     this.ensureRuntime(hash, segments)
     this.syncEntryMirror(entry)
+    if (hadPendingDestroy) this.reconcileTransport(hash).catch(ignoreDestroyError)
   }
 
   async unsubscribe ($doc, { intent = 'subscribe' } = {}) {
@@ -523,7 +525,7 @@ export class DocSubscriptions {
 
   async reconcileTransport (hash) {
     const entry = this.getOrCreateEntry(hash)
-    entry.targetMode = this.getDesiredTransportMode(hash)
+    entry.targetMode = this.getTargetTransportMode(hash)
     if (entry.phase === 'transition' && entry.reconcilePromise) return entry.reconcilePromise
     const next = Promise.resolve()
       .catch(ignoreDestroyError)
@@ -546,7 +548,7 @@ export class DocSubscriptions {
     const entry = this.getOrCreateEntry(hash)
     while (true) {
       let doc = entry.runtime
-      const desiredMode = entry.targetMode = this.getDesiredTransportMode(hash)
+      const desiredMode = entry.targetMode = this.getTargetTransportMode(hash)
       const currentMode = doc?.activeTransportMode ?? entry.mode
       entry.mode = currentMode
       if (desiredMode === currentMode) return
@@ -724,6 +726,18 @@ export class DocSubscriptions {
       }
     }
     return hasFetchBackedOwner ? 'fetch' : 'idle'
+  }
+
+  getTargetTransportMode (hash) {
+    const desiredMode = this.getDesiredTransportMode(hash)
+    if (desiredMode !== 'idle') return desiredMode
+    const entry = this.entries.get(hash)
+    const activeMode = entry?.runtime?.activeTransportMode ?? entry?.mode
+    const canReuseLiveTransport =
+      entry?.pendingDestroy &&
+      this.getEntryTotalCount(entry) === 0 &&
+      activeMode === 'subscribe'
+    return canReuseLiveTransport ? 'subscribe' : 'idle'
   }
 
   removeAllOwnersFromEntry (hash) {

--- a/packages/teamplay/test/sub$.js
+++ b/packages/teamplay/test/sub$.js
@@ -5,6 +5,7 @@ import { $, sub, unsub, aggregation } from '../src/index.ts'
 import { get as _get, del as _del } from '../src/orm/dataTree.js'
 import { getConnection } from '../src/orm/connection.ts'
 import { hashQuery, querySubscriptions } from '../src/orm/Query.js'
+import { docSubscriptions } from '../src/orm/Doc.js'
 import { aggregationSubscriptions } from '../src/orm/Aggregation.js'
 import { getPrivateData } from '../src/orm/privateData.js'
 import { getRoot, getRootSignal, ROOT_ID } from '../src/orm/Root.ts'
@@ -17,6 +18,10 @@ function cbPromise (fn) {
   return new Promise((resolve, reject) => {
     fn((err, result) => err ? reject(err) : resolve(result))
   })
+}
+
+function wait (ms) {
+  return new Promise(resolve => setTimeout(resolve, ms))
 }
 
 function afterEachTestGcShareDb () {
@@ -122,6 +127,51 @@ describe('$sub() function', () => {
     const game = $game.get()
     assert.equal(game.id, gameId)
     // TODO: When returning data from .get(), it should be wrapped into Proxy too
+  })
+})
+
+describe('$sub() direct document transport grace', () => {
+  afterEachTestGc()
+  afterEachTestGcShareDb()
+
+  it('reuses the real ShareDB live subscription across quick unsub/sub', async () => {
+    const previousGcDelay = getSubscriptionGcDelay()
+    const gameId = '_public_transport_grace'
+    const hash = JSON.stringify(['games', gameId])
+    let $resubscribedGame
+    let firstUnsubscribePromise
+
+    try {
+      setSubscriptionGcDelay(60_000)
+      const $game = await sub($.games[gameId])
+      const shareDoc = getConnection().get('games', gameId)
+      await cbPromise(cb => shareDoc.create({ name: 'Transport Grace' }, cb))
+      const runtime = docSubscriptions.docs.get(hash)
+
+      firstUnsubscribePromise = unsub($game)
+      await wait(0)
+
+      assert.equal(shareDoc.subscribed, true, 'ShareDB wire stays live during grace')
+      assert.equal(docSubscriptions.docs.get(hash), runtime)
+
+      $resubscribedGame = await sub($.games[gameId])
+      await firstUnsubscribePromise
+
+      assert.equal($resubscribedGame.name.get(), 'Transport Grace')
+      assert.equal(shareDoc.subscribed, true)
+      assert.equal(docSubscriptions.docs.get(hash), runtime, 'public sub() adopts the same runtime')
+
+      await cbPromise(cb => shareDoc.del(cb))
+    } finally {
+      setSubscriptionGcDelay(0)
+      if ($resubscribedGame) await unsub($resubscribedGame)
+      await firstUnsubscribePromise?.catch(() => {})
+      await docSubscriptions.flushPendingDestroys()
+      setSubscriptionGcDelay(previousGcDelay)
+    }
+
+    assert.equal(docSubscriptions.docs.has(hash), false)
+    assert.equal(Object.keys(getConnection().collections?.games || {}).length, 0)
   })
 })
 

--- a/packages/teamplay/test/subscriptionManagers.js
+++ b/packages/teamplay/test/subscriptionManagers.js
@@ -112,6 +112,16 @@ function wait (ms) {
   return new Promise(resolve => setTimeout(resolve, ms))
 }
 
+function createDeferred () {
+  let resolveDeferred
+  let rejectDeferred
+  const promise = new Promise((resolve, reject) => {
+    resolveDeferred = resolve
+    rejectDeferred = reject
+  })
+  return { promise, resolve: resolveDeferred, reject: rejectDeferred }
+}
+
 function createDocSignal (collection, docId) {
   return {
     [SEGMENTS]: [collection, docId],
@@ -195,6 +205,60 @@ class PendingMockDoc extends MockDoc {
 
   dispose () {
     this.initialized = false
+  }
+}
+
+class LifecycleMockDoc extends MockDoc {
+  destroyCount = 0
+  disposeCount = 0
+
+  async destroy () {
+    this.destroyCount += 1
+  }
+
+  dispose () {
+    this.disposeCount += 1
+    this.initialized = false
+  }
+}
+
+class GatedSubscribeMockDoc extends LifecycleMockDoc {
+  subscribeGate = createDeferred()
+
+  async subscribe ({ mode } = {}) {
+    const nextMode = mode || 'subscribe'
+    this.events.push(`subscribe:${nextMode}:start`)
+    await this.subscribeGate.promise
+    this.requestedTransportMode = nextMode
+    this.activeTransportMode = nextMode
+    this.subscribed = nextMode === 'subscribe'
+    this.events.push(`subscribe:${nextMode}:done`)
+  }
+}
+
+class GatedUnsubscribeMockDoc extends LifecycleMockDoc {
+  unsubscribeGate = createDeferred()
+
+  async unsubscribe () {
+    const activeMode = this.activeTransportMode
+    this.events.push(`unsubscribe:${activeMode}:start`)
+    await this.unsubscribeGate.promise
+    this.activeTransportMode = 'idle'
+    this.subscribed = false
+    this.events.push(`unsubscribe:${activeMode}:done`)
+  }
+}
+
+class FailOnceUnsubscribeMockDoc extends LifecycleMockDoc {
+  shouldFailUnsubscribe = true
+
+  async unsubscribe () {
+    if (this.shouldFailUnsubscribe) {
+      this.shouldFailUnsubscribe = false
+      this.events.push(`unsubscribe:${this.activeTransportMode}:failed`)
+      throw new Error('mock unsubscribe failure')
+    }
+    await super.unsubscribe()
   }
 }
 
@@ -1459,6 +1523,520 @@ describe('Subscription GC grace delay', () => {
     await wait(gcDelay + 10)
     assert.equal(docManager.docs.get(docHash), undefined, 'no late timer side effects for docs')
     assert.equal(queryManager.queries.get(queryHash), undefined, 'no late timer side effects for queries')
+  })
+})
+
+describe('Direct document transport grace', () => {
+  afterEach(assertTrackedManagersAndReset)
+  const gcDelay = 60_000
+
+  beforeEach(() => {
+    setSubscriptionGcDelay(gcDelay)
+  })
+
+  afterEach(() => {
+    __resetSubscriptionGcDelayForTests()
+  })
+
+  it('keeps the final live transport subscribed while destroy is pending', async () => {
+    const manager = createTrackedDocManager(LifecycleMockDoc)
+    const $doc = createDocSignal('gamesTransportGrace', 'live-pending')
+    const hash = JSON.stringify($doc[SEGMENTS])
+    let unsubscribePromise
+
+    try {
+      await manager.subscribe($doc)
+      const doc = manager.docs.get(hash)
+      unsubscribePromise = manager.unsubscribe($doc)
+      await wait(0)
+
+      const entry = manager.entries.get(hash)
+      assert.ok(entry?.pendingDestroy, 'destroy should be pending during grace')
+      assert.equal(entry.owners.size, 0, 'the transport has no active owners')
+      assert.equal(manager.subCount.get(hash), 0, 'the pending transport is tracked with zero owners')
+      assert.equal(doc.activeTransportMode, 'subscribe', 'the live transport should remain subscribed')
+      assert.deepEqual(doc.events, ['subscribe:subscribe'], 'wire unsubscribe should be deferred')
+    } finally {
+      await manager.flushPendingDestroys().catch(() => {})
+      await unsubscribePromise?.catch(() => {})
+      await manager.clear()
+    }
+  })
+
+  it('lets a quick live owner adopt the same wire subscription', async () => {
+    const manager = createTrackedDocManager(LifecycleMockDoc)
+    const $docA = createDocSignal('gamesTransportGrace', 'live-adopt')
+    const $docB = createDocSignal('gamesTransportGrace', 'live-adopt')
+    const hash = JSON.stringify($docA[SEGMENTS])
+    let firstUnsubscribePromise
+
+    try {
+      await manager.subscribe($docA)
+      const doc = manager.docs.get(hash)
+      firstUnsubscribePromise = manager.unsubscribe($docA)
+      await wait(0)
+
+      await manager.subscribe($docB)
+      await firstUnsubscribePromise
+
+      assert.equal(manager.docs.get(hash), doc, 'the runtime instance should be reused')
+      assert.equal(manager.pendingDestroyTimers.has(hash), false, 'adoption should cancel pending destroy')
+      assert.equal(doc.activeTransportMode, 'subscribe')
+      const events = [...doc.events]
+      assert.deepEqual(events, ['subscribe:subscribe'], 'adoption should not churn the wire transport')
+    } finally {
+      setSubscriptionGcDelay(0)
+      await manager.unsubscribe($docB).catch(() => {})
+      await firstUnsubscribePromise?.catch(() => {})
+      await manager.clear()
+    }
+  })
+
+  it('tears down the live transport exactly once when grace expires', async () => {
+    const manager = createTrackedDocManager(LifecycleMockDoc)
+    const $doc = createDocSignal('gamesTransportGrace', 'live-expire')
+    const hash = JSON.stringify($doc[SEGMENTS])
+
+    await manager.subscribe($doc)
+    const doc = manager.docs.get(hash)
+    const unsubscribePromise = manager.unsubscribe($doc)
+    await wait(0)
+
+    await manager.flushPendingDestroys()
+    await unsubscribePromise
+
+    assert.deepEqual(doc.events, ['subscribe:subscribe', 'unsubscribe:subscribe'])
+    assert.equal(doc.destroyCount, 1)
+    assert.equal(doc.disposeCount, 1)
+    assert.equal(manager.entries.has(hash), false)
+    assert.equal(manager.docs.has(hash), false)
+    assert.equal(manager.subCount.has(hash), false)
+    assert.equal(manager.pendingDestroyTimers.has(hash), false)
+  })
+
+  it('keeps zero-delay live cleanup eager', async () => {
+    setSubscriptionGcDelay(0)
+    const manager = createTrackedDocManager(LifecycleMockDoc)
+    const $doc = createDocSignal('gamesTransportGrace', 'live-zero-delay')
+    const hash = JSON.stringify($doc[SEGMENTS])
+
+    await manager.subscribe($doc)
+    const doc = manager.docs.get(hash)
+    await manager.unsubscribe($doc)
+
+    assert.deepEqual(doc.events, ['subscribe:subscribe', 'unsubscribe:subscribe'])
+    assert.equal(doc.destroyCount, 1)
+    assert.equal(doc.disposeCount, 1)
+    assert.equal(manager.entries.has(hash), false)
+  })
+
+  it('keeps fetch transport eager and refetches on a quick new owner', async () => {
+    const manager = createTrackedDocManager(LifecycleMockDoc)
+    const $rootA = getRootSignal({ rootId: '_doc_grace_fetch_a', fetchOnly: true })
+    const $rootB = getRootSignal({ rootId: '_doc_grace_fetch_b', fetchOnly: true })
+    const $docA = $rootA.games._fetchGraceDoc
+    const $docB = $rootB.games._fetchGraceDoc
+    const hash = JSON.stringify(['games', '_fetchGraceDoc'])
+    let firstUnsubscribePromise
+
+    try {
+      await manager.subscribe($docA)
+      const doc = manager.docs.get(hash)
+      firstUnsubscribePromise = manager.unsubscribe($docA)
+      await wait(0)
+
+      assert.equal(doc.activeTransportMode, 'idle', 'fetch transport should close before runtime GC')
+      assert.deepEqual(doc.events, ['subscribe:fetch', 'unsubscribe:fetch'])
+
+      await manager.subscribe($docB)
+      await firstUnsubscribePromise
+
+      assert.equal(manager.docs.get(hash), doc, 'the runtime may still be reused')
+      assert.deepEqual(doc.events, [
+        'subscribe:fetch',
+        'unsubscribe:fetch',
+        'subscribe:fetch'
+      ], 'a new fetch owner must perform a fresh fetch')
+    } finally {
+      setSubscriptionGcDelay(0)
+      await manager.unsubscribe($docB).catch(() => {})
+      await firstUnsubscribePromise?.catch(() => {})
+      await manager.clear()
+    }
+  })
+
+  it('switches a grace-retained live transport to fetch for a fetch-only owner', async () => {
+    const manager = createTrackedDocManager(LifecycleMockDoc)
+    const $liveRoot = getRootSignal({ rootId: '_doc_grace_live_handoff', fetchOnly: false })
+    const $fetchRoot = getRootSignal({ rootId: '_doc_grace_fetch_handoff', fetchOnly: true })
+    const $liveDoc = $liveRoot.games._liveToFetchGraceDoc
+    const $fetchDoc = $fetchRoot.games._liveToFetchGraceDoc
+    const hash = JSON.stringify(['games', '_liveToFetchGraceDoc'])
+    let liveUnsubscribePromise
+
+    try {
+      await manager.subscribe($liveDoc)
+      const doc = manager.docs.get(hash)
+      liveUnsubscribePromise = manager.unsubscribe($liveDoc)
+      await wait(0)
+
+      assert.equal(doc.activeTransportMode, 'subscribe')
+      await manager.subscribe($fetchDoc)
+      await liveUnsubscribePromise
+
+      assert.equal(manager.docs.get(hash), doc)
+      assert.equal(doc.activeTransportMode, 'fetch')
+      assert.deepEqual(doc.events, [
+        'subscribe:subscribe',
+        'unsubscribe:subscribe',
+        'subscribe:fetch'
+      ])
+    } finally {
+      setSubscriptionGcDelay(0)
+      await manager.unsubscribe($fetchDoc).catch(() => {})
+      await liveUnsubscribePromise?.catch(() => {})
+      await manager.clear()
+    }
+  })
+
+  it('downgrades mixed live and fetch owners immediately', async () => {
+    const manager = createTrackedDocManager(LifecycleMockDoc)
+    const $fetchRoot = getRootSignal({ rootId: '_doc_grace_mixed_fetch', fetchOnly: true })
+    const $liveRoot = getRootSignal({ rootId: '_doc_grace_mixed_live', fetchOnly: false })
+    const $fetchDoc = $fetchRoot.games._mixedGraceDoc
+    const $liveDoc = $liveRoot.games._mixedGraceDoc
+    const hash = JSON.stringify(['games', '_mixedGraceDoc'])
+
+    await manager.subscribe($fetchDoc)
+    await manager.subscribe($liveDoc)
+    const doc = manager.docs.get(hash)
+
+    await manager.unsubscribe($liveDoc)
+
+    assert.equal(doc.activeTransportMode, 'fetch')
+    assert.equal(manager.pendingDestroyTimers.has(hash), false, 'a real fetch owner prevents GC')
+    assert.deepEqual(doc.events, [
+      'subscribe:fetch',
+      'unsubscribe:fetch',
+      'subscribe:subscribe',
+      'unsubscribe:subscribe',
+      'subscribe:fetch'
+    ])
+
+    const fetchUnsubscribePromise = manager.unsubscribe($fetchDoc)
+    await wait(0)
+    assert.equal(doc.activeTransportMode, 'idle', 'final fetch transport should close eagerly')
+    assert.ok(manager.pendingDestroyTimers.has(hash), 'only runtime GC remains delayed')
+    await manager.flushPendingDestroys()
+    await fetchUnsubscribePromise
+  })
+
+  it('does not let a query retain adopt an ownerless live transport', async () => {
+    const manager = createTrackedDocManager(LifecycleMockDoc)
+    const $doc = createDocSignal('gamesTransportGrace', 'query-retain-handoff')
+    const hash = JSON.stringify($doc[SEGMENTS])
+
+    await manager.subscribe($doc)
+    const doc = manager.docs.get(hash)
+    const unsubscribePromise = manager.unsubscribe($doc)
+    await wait(0)
+    assert.equal(doc.activeTransportMode, 'subscribe')
+
+    manager.retain($doc)
+    await unsubscribePromise
+    await wait(0)
+
+    const entry = manager.entries.get(hash)
+    assert.equal(entry.retainCount, 1)
+    assert.equal(entry.owners.size, 0)
+    assert.equal(entry.pendingDestroy, null)
+    assert.equal(doc.activeTransportMode, 'idle', 'query retain keeps data, not direct live transport')
+    assert.deepEqual(doc.events, ['subscribe:subscribe', 'unsubscribe:subscribe'])
+
+    setSubscriptionGcDelay(0)
+    await manager.release($doc)
+  })
+
+  it('retains an in-flight live subscribe when the final owner leaves', async () => {
+    const manager = createTrackedDocManager(GatedSubscribeMockDoc)
+    const $docA = createDocSignal('gamesTransportGrace', 'subscribe-in-flight')
+    const $docB = createDocSignal('gamesTransportGrace', 'subscribe-in-flight')
+    const hash = JSON.stringify($docA[SEGMENTS])
+    let firstUnsubscribePromise
+
+    try {
+      const subscribePromise = manager.subscribe($docA)
+      await wait(0)
+      const doc = manager.docs.get(hash)
+      firstUnsubscribePromise = manager.unsubscribe($docA)
+      await wait(0)
+
+      doc.subscribeGate.resolve()
+      await subscribePromise
+      assert.equal(doc.activeTransportMode, 'subscribe')
+      assert.ok(manager.pendingDestroyTimers.has(hash))
+
+      await manager.subscribe($docB)
+      await firstUnsubscribePromise
+
+      assert.equal(manager.docs.get(hash), doc)
+      assert.deepEqual(doc.events, [
+        'subscribe:subscribe:start',
+        'subscribe:subscribe:done'
+      ], 'adoption should reuse the completed in-flight subscription')
+    } finally {
+      setSubscriptionGcDelay(0)
+      await manager.unsubscribe($docB).catch(() => {})
+      await firstUnsubscribePromise?.catch(() => {})
+      await manager.clear()
+    }
+  })
+
+  it('resubscribes once when a new owner arrives during teardown', async () => {
+    const manager = createTrackedDocManager(GatedUnsubscribeMockDoc)
+    const $docA = createDocSignal('gamesTransportGrace', 'teardown-in-flight')
+    const $docB = createDocSignal('gamesTransportGrace', 'teardown-in-flight')
+    const hash = JSON.stringify($docA[SEGMENTS])
+
+    await manager.subscribe($docA)
+    const doc = manager.docs.get(hash)
+    const firstUnsubscribePromise = manager.unsubscribe($docA)
+    await wait(0)
+    const flushPromise = manager.flushPendingDestroys()
+    await wait(0)
+
+    assert.deepEqual(doc.events, [
+      'subscribe:subscribe',
+      'unsubscribe:subscribe:start'
+    ])
+
+    const secondSubscribePromise = manager.subscribe($docB)
+    doc.unsubscribeGate.resolve()
+    await Promise.all([firstUnsubscribePromise, flushPromise, secondSubscribePromise])
+
+    assert.equal(manager.docs.get(hash), doc)
+    assert.equal(doc.activeTransportMode, 'subscribe')
+    assert.equal(doc.destroyCount, 0)
+    assert.deepEqual(doc.events, [
+      'subscribe:subscribe',
+      'unsubscribe:subscribe:start',
+      'unsubscribe:subscribe:done',
+      'subscribe:subscribe'
+    ])
+
+    setSubscriptionGcDelay(0)
+    await manager.unsubscribe($docB)
+  })
+
+  it('closes the wire at expiry but waits for pending operations before destroy', async () => {
+    const manager = createTrackedDocManager(PendingMockDoc)
+    const $doc = createDocSignal('gamesTransportGrace', 'pending-operation')
+    const hash = JSON.stringify($doc[SEGMENTS])
+
+    await manager.subscribe($doc)
+    const doc = manager.docs.get(hash)
+    doc.setPending(true)
+    const unsubscribePromise = manager.unsubscribe($doc)
+    await wait(0)
+
+    assert.equal(doc.activeTransportMode, 'subscribe')
+    await manager.flushPendingDestroys()
+
+    assert.equal(doc.activeTransportMode, 'idle', 'wire closes when grace expires')
+    assert.equal(doc.destroyed, false, 'runtime waits for pending operations')
+    assert.ok(manager.docs.has(hash))
+
+    doc.setPending(false)
+    await unsubscribePromise
+    assert.equal(doc.destroyed, true)
+    assert.equal(manager.entries.has(hash), false)
+  })
+
+  it('clear bypasses grace and leaves no late cleanup work', async () => {
+    const manager = createTrackedDocManager(LifecycleMockDoc)
+    const $doc = createDocSignal('gamesTransportGrace', 'clear-during-grace')
+    const hash = JSON.stringify($doc[SEGMENTS])
+
+    await manager.subscribe($doc)
+    const doc = manager.docs.get(hash)
+    const unsubscribePromise = manager.unsubscribe($doc)
+    await wait(0)
+    assert.ok(manager.pendingDestroyTimers.has(hash))
+
+    await manager.clear()
+    await unsubscribePromise
+
+    assert.deepEqual(doc.events, ['subscribe:subscribe', 'unsubscribe:subscribe'])
+    assert.equal(doc.destroyCount, 1)
+    assert.equal(doc.disposeCount, 1)
+    assert.equal(manager.entries.size, 0)
+    assert.equal(manager.ownerRecords.size, 0)
+    assert.equal(manager.pendingDestroyTimers.size, 0)
+  })
+
+  it('root cleanup keeps shared ownership and eagerly destroys the final owner', async () => {
+    const manager = createTrackedDocManager(LifecycleMockDoc)
+    const $rootA = getRootSignal({ rootId: '_doc_grace_root_a', fetchOnly: false })
+    const $rootB = getRootSignal({ rootId: '_doc_grace_root_b', fetchOnly: false })
+    const $docA = $rootA.games._rootCleanupGraceDoc
+    const $docB = $rootB.games._rootCleanupGraceDoc
+    const hash = JSON.stringify(['games', '_rootCleanupGraceDoc'])
+
+    await manager.subscribe($docA)
+    await manager.subscribe($docB)
+    const doc = manager.docs.get(hash)
+
+    await manager.releaseRootOwnedSubscriptions($rootA[ROOT_ID])
+    assert.equal(doc.activeTransportMode, 'subscribe')
+    assert.equal(doc.destroyCount, 0)
+    assert.equal(manager.subCount.get(hash), 1)
+
+    await manager.releaseRootOwnedSubscriptions($rootB[ROOT_ID])
+    assert.deepEqual(doc.events, ['subscribe:subscribe', 'unsubscribe:subscribe'])
+    assert.equal(doc.destroyCount, 1)
+    assert.equal(doc.disposeCount, 1)
+    assert.equal(manager.entries.has(hash), false)
+    assert.equal(manager.pendingDestroyTimers.has(hash), false)
+  })
+
+  it('keeps failed expiry cleanup observable and retryable', async () => {
+    const manager = createTrackedDocManager(FailOnceUnsubscribeMockDoc)
+    const $doc = createDocSignal('gamesTransportGrace', 'unsubscribe-failure')
+    const hash = JSON.stringify($doc[SEGMENTS])
+
+    await manager.subscribe($doc)
+    const doc = manager.docs.get(hash)
+    const unsubscribePromise = manager.unsubscribe($doc)
+    const unsubscribeRejection = assert.rejects(unsubscribePromise, /mock unsubscribe failure/)
+    await wait(0)
+
+    await assert.rejects(manager.flushPendingDestroys(), /mock unsubscribe failure/)
+    await unsubscribeRejection
+
+    assert.equal(doc.activeTransportMode, 'subscribe')
+    assert.ok(manager.docs.has(hash), 'failed runtime remains tracked for retry')
+    assert.equal(manager.pendingDestroyTimers.has(hash), false, 'failed timer is settled once')
+
+    await manager.clear()
+    assert.deepEqual(doc.events, [
+      'subscribe:subscribe',
+      'unsubscribe:subscribe:failed',
+      'unsubscribe:subscribe'
+    ])
+    assert.equal(manager.entries.size, 0)
+  })
+
+  it('keeps one live transport through repeated same-hash churn', async () => {
+    const manager = createTrackedDocManager(LifecycleMockDoc)
+    const hash = JSON.stringify(['gamesTransportGrace', 'same-hash-stress'])
+    let $activeDoc = createDocSignal('gamesTransportGrace', 'same-hash-stress')
+
+    await manager.subscribe($activeDoc)
+    const runtime = manager.docs.get(hash)
+
+    for (let i = 0; i < 50; i++) {
+      const unsubscribePromise = manager.unsubscribe($activeDoc)
+      await wait(0)
+      assert.equal(manager.pendingDestroyTimers.size, 1)
+
+      const $nextDoc = createDocSignal('gamesTransportGrace', 'same-hash-stress')
+      await manager.subscribe($nextDoc)
+      await unsubscribePromise
+      $activeDoc = $nextDoc
+      assert.equal(manager.docs.get(hash), runtime)
+      assert.equal(manager.pendingDestroyTimers.size, 0)
+    }
+
+    assert.deepEqual(runtime.events, ['subscribe:subscribe'])
+    assert.equal(manager.docs.size, 1)
+    assert.equal(manager.entries.size, 1)
+
+    const unsubscribePromise = manager.unsubscribe($activeDoc)
+    await manager.flushPendingDestroys()
+    await unsubscribePromise
+    assert.equal(manager.entries.size, 0)
+  })
+
+  it('bounds abandoned unique live transports by pending GC and flushes all of them', async () => {
+    const manager = createTrackedDocManager(LifecycleMockDoc)
+    const unsubscribePromises = []
+    const abandonedCount = 30
+
+    for (let i = 0; i < abandonedCount; i++) {
+      const $doc = createDocSignal('gamesTransportGraceUnique', `abandoned-${i}`)
+      await manager.subscribe($doc)
+      unsubscribePromises.push(manager.unsubscribe($doc))
+    }
+    await wait(0)
+
+    assert.equal(manager.docs.size, abandonedCount)
+    assert.equal(manager.pendingDestroyTimers.size, abandonedCount)
+    assert.equal(manager.entries.size, abandonedCount)
+
+    await manager.flushPendingDestroys()
+    await Promise.all(unsubscribePromises)
+
+    assert.equal(manager.docs.size, 0)
+    assert.equal(manager.pendingDestroyTimers.size, 0)
+    assert.equal(manager.entries.size, 0)
+    assert.equal(manager.ownerRecords.size, 0)
+  })
+})
+
+describe('Transport grace non-goals', () => {
+  afterEach(assertTrackedManagersAndReset)
+  const gcDelay = 60_000
+
+  beforeEach(() => {
+    setSubscriptionGcDelay(gcDelay)
+  })
+
+  afterEach(() => {
+    __resetSubscriptionGcDelayForTests()
+  })
+
+  it('keeps query transport teardown eager while retaining its runtime for GC', async () => {
+    const manager = createTrackedQueryManager(MockQuery)
+    const $query = createMockQuerySignal('gamesQueryGrace', { active: true })
+    const hash = $query[QUERY_HASH]
+
+    await manager.subscribe($query)
+    const query = manager.queries.get(hash)
+    const unsubscribePromise = manager.unsubscribe($query)
+    await wait(0)
+
+    assert.deepEqual(query.events, ['subscribe:subscribe', 'unsubscribe:subscribe'])
+    assert.equal(query.activeTransportMode, 'idle')
+    assert.ok(manager.queries.has(hash), 'only materialized query runtime remains until GC')
+    assert.equal(manager.pendingDestroyTimers.size, 1)
+
+    await manager.flushPendingDestroys()
+    await unsubscribePromise
+  })
+
+  it('keeps aggregation transport teardown eager while retaining its runtime for GC', async () => {
+    const manager = createTrackedQueryManager(MockQuery)
+    manager.runtimeKind = 'aggregation'
+    const $root = getRootSignal({ rootId: '_aggregation_transport_grace_non_goal' })
+    const $aggregation = getAggregationSignal(
+      'gamesAggregationGrace',
+      { $aggregate: [{ $match: { active: true } }] },
+      { root: $root }
+    )
+    const hash = $aggregation[QUERY_HASH]
+
+    await manager.subscribe($aggregation)
+    const aggregation = manager.queries.get(hash)
+    const unsubscribePromise = manager.unsubscribe($aggregation)
+    await wait(0)
+
+    assert.deepEqual(aggregation.events, ['subscribe:subscribe', 'unsubscribe:subscribe'])
+    assert.equal(aggregation.activeTransportMode, 'idle')
+    assert.ok(manager.queries.has(hash), 'only materialized aggregation runtime remains until GC')
+    assert.equal(manager.pendingDestroyTimers.size, 1)
+
+    await manager.flushPendingDestroys()
+    await unsubscribePromise
   })
 })
 

--- a/tasks.md
+++ b/tasks.md
@@ -103,6 +103,21 @@ Docs should reinforce the intended object-tree mental model.
 - [ ] Keep query metadata docs clear about `ids`, `extra`, and document-id collisions.
 - [ ] Keep TypeScript support docs clear about generated env setup, schema default interfaces, and known module-resolution requirements.
 
+### 7. Direct Document Transport Grace
+
+Keep the existing GC delay useful for short-lived direct live-document
+handoffs without retaining fetch, query, or aggregation transports.
+
+- [x] Capture the `subscribe -> unsubscribe -> subscribe` wire churn in a failing characterization test.
+- [x] Keep an ownerless direct live transport only while its pending destroy exists.
+- [x] Preserve eager fetch behavior and immediate mixed-mode reconciliation.
+- [x] Prevent query retain from adopting an ownerless direct live transport.
+- [x] Cover in-flight transitions, force cleanup, root ownership, pending operations, failures, and bounded retention.
+- [x] Verify the public `sub()` / `unsub()` path against a real test ShareDB connection.
+- [x] Pass full server, client, type, Babel, lint, and build gates independently.
+- [ ] Obtain a clean combined `yarn test`; the current failure is reproduced unchanged on clean `origin/master` in the query root-finalization afterEach.
+- [ ] Repeat the measured downstream LMS route trace and smoke after package integration.
+
 ## Verification Checklist
 
 Use the smallest useful verification while iterating, then broaden before committing runtime changes.


### PR DESCRIPTION
## Summary

- keep the direct live ShareDB document transport subscribed while the existing GC grace timer retains its runtime
- let rapid `unsub()` / `sub()` churn adopt the same wire subscription instead of paying another transport round trip
- preserve eager transport teardown for fetch-only documents, queries, aggregations, root cleanup, and explicit clear
- document the lifecycle contract and the TDD investigation

## Implementation

`DocSubscriptions` now derives a grace-aware target transport mode. An ownerless direct live document stays in `subscribe` mode only while its pending destroy timer is active. A new direct owner cancels the timer and adopts the transport. Grace expiry still unsubscribes and destroys exactly once. Query retention cancels document grace and reconciles the now-ownerless direct transport back to idle, so query materialization does not accidentally keep an unrelated wire subscription open.

## Validation

- 18 focused direct transport grace and non-goal tests pass
- 31 related retain, GC, and grace tests pass
- public `sub()` / `unsub()` integration coverage passes against real ShareDB
- server suite has passed once with 444 passing and 4 pending
- client suite: 4 suites, 103 tests pass
- Babel plugin: 30 tests pass
- internal and external type suites pass
- lint, build, and `git diff --check` pass

## Known baseline flake

The pre-commit full server run intermittently fails in the existing `root finalization` afterEach invariant (`rootCloseQueries`: runtime view is `null`, canonical entry is `undefined`). The identical failure was reproduced in a clean detached `origin/master` worktree; its isolated root finalization suite passes. This PR does not modify query cleanup.

## Artifact

See `docs/direct-doc-transport-grace-plan.md` for the decision matrix, race coverage, non-goals, measurements, and downstream LMS integration plan.