### PR TITLE
Collapse sequential Suspense retries in a shared group

### DIFF
--- a/docs/guide/react-integration.md
+++ b/docs/guide/react-integration.md
@@ -98,6 +98,56 @@ Avoid legacy hook names like `useDoc`, `useQuery`, `useBatchDoc`, and
 `useBatchQuery` in new code. The public API is the object-tree subscription API:
 `useSub`, `useAsyncSub`, and `useBatchSub`.
 
+### Grouping Suspense retries
+
+Use `SuspenseGroup` around an application subtree that should share one loading
+boundary. This is useful for route shells where nested `observer()` components
+discover several subscription waves in sequence:
+
+```javascript
+import { SuspenseGroup } from 'teamplay'
+
+function PlayerRoute ({ children }) {
+  return (
+    <SuspenseGroup fallback={<PlayerSkeleton />}>
+      {children}
+    </SuspenseGroup>
+  )
+}
+```
+
+Inside the group, default Suspense boundaries added by `observer()` are
+consolidated into the group boundary. TeamPlay automatically schedules retries
+for initial `useSub()`, `useBatchSub()`, and `useSuspendMemo()` promises. An
+observer with an explicit `suspenseProps.fallback` keeps its own boundary.
+Outside `SuspenseGroup`, observer behavior is unchanged.
+
+For a stable promise that TeamPlay does not create, such as a memoized
+`React.lazy()` loader, register it explicitly:
+
+```javascript
+import React from 'react'
+import { useSuspenseGroupScheduleUpdate } from 'teamplay'
+
+let viewPromise
+const loadView = () => {
+  if (!viewPromise) viewPromise = import('./LoadedView.js')
+  return viewPromise
+}
+const LoadedView = React.lazy(loadView)
+
+function LazyView (props) {
+  const scheduleUpdate = useSuspenseGroupScheduleUpdate()
+  const promise = loadView()
+  scheduleUpdate?.(promise)
+  return <LoadedView {...props} />
+}
+```
+
+The loader must return the same in-flight promise on repeated renders. The hook
+returns `undefined` outside a group, so the component can retain its normal
+local Suspense fallback there.
+
 ## Creating and Waiting for Documents
 
 Sometimes, you might need to create a document if it doesn't exist yet. Here's how to do it:

--- a/packages/teamplay/README.md
+++ b/packages/teamplay/README.md
@@ -45,6 +45,17 @@ Why:
 ### `useSuspendMemo(factory, deps)`
 
 Use it when the suspend gate is local to one observer component instance.
+Think of it as a render gate, not as an asynchronous version of `useMemo()`:
+
+1. The factory runs synchronously during render.
+2. A normal return value is cached until the dependencies change.
+3. If the factory throws a thenable, the same pending thenable is rethrown on
+   every retry for that hook slot.
+4. After the thenable settles, the factory runs again. It must observe that the
+   external signal or state is now ready, or surface a stored error.
+
+Do not pass an `async` factory or return a Promise. A returned Promise is treated
+as an ordinary completed value and does not suspend; the factory must throw it.
 
 ```js
 import { observer, useSuspendMemo } from 'teamplay'
@@ -54,14 +65,15 @@ const Component = observer(({ $stage, userId, stageUserStore }) => {
     if (!stageUserStore?.startedAt) {
       throw $stage.join(userId)
     }
-  }, [$stage.getId()])
+  }, [$stage.getId(), userId, !!stageUserStore?.startedAt])
 
   return <span>Ready</span>
 })
 ```
 
 This keeps the same pending thenable for the same hook slot while the component
-instance is alive.
+instance is alive. Dependencies identify the gate inputs; changing them can
+start a new operation and does not cancel the previous one.
 
 ### `useSuspendMemoByKey(key, factory, deps)`
 
@@ -91,6 +103,10 @@ This is the right choice when:
 - the component may remount while the promise is still pending;
 - two different components may trigger the same async operation;
 - the operation should behave like a single in-flight business task.
+
+`useSuspendMemoByKey()` deduplicates only the in-flight operation. It does not
+cache a completed result; the external signal or state remains the source of
+truth after the Promise settles.
 
 ## License
 

--- a/packages/teamplay/src/index.ts
+++ b/packages/teamplay/src/index.ts
@@ -210,6 +210,10 @@ export {
   default as useSuspendMemo,
   useSuspendMemoByKey
 } from './react/useSuspendMemo.ts'
+export {
+  SuspenseGroup,
+  useSuspenseGroupScheduleUpdate
+} from './react/wrapIntoSuspense.js'
 export const observer = runtimeObserver as unknown as ObserverFunction
 export { emit, useOn, useEmit } from './orm/events.js'
 export {

--- a/packages/teamplay/src/react/useSub.ts
+++ b/packages/teamplay/src/react/useSub.ts
@@ -2,6 +2,7 @@ import { useRef, useDeferredValue } from 'react'
 import type { AggregationFunction, AggregationParams, ClientAggregationFunction } from '@teamplay/utils/aggregation'
 import sub from '../orm/sub.ts'
 import { useScheduleUpdate, useCache, useDefer } from './helpers.ts'
+import { useSuspenseGroupScheduleUpdate } from './wrapIntoSuspense.js'
 import executionContextTracker from './executionContextTracker.ts'
 import * as promiseBatcher from './promiseBatcher.ts'
 import { getPrivateData } from '../orm/privateData.js'
@@ -168,7 +169,7 @@ export function useAsyncSub<TOutput = unknown, TCollection extends string = stri
 
 export function useAsyncSub (signal: unknown, params?: unknown, options?: UseSubOptions): unknown {
   const normalized = normalizeUseSubArgs(signal, params, options)
-  return runUseSub(normalized.signal, normalized.params, { ...normalized.options, async: true })
+  return useNormalizedSub(normalized.signal, normalized.params, { ...normalized.options, async: true })
 }
 
 /**
@@ -419,7 +420,7 @@ export default function useSub<TOutput = unknown, TCollection extends string = s
 
 export default function useSub (signal: unknown, params?: unknown, options?: UseSubOptions): unknown {
   const normalized = normalizeUseSubArgs(signal, params, options)
-  return runUseSub(normalized.signal, normalized.params, normalized.options)
+  return useNormalizedSub(normalized.signal, normalized.params, normalized.options)
 }
 
 function normalizeUseSubArgs (
@@ -442,8 +443,9 @@ function isUseSubOptions (value: unknown): value is UseSubOptions {
   return Object.keys(value).every(key => USE_SUB_OPTION_KEYS.has(key))
 }
 
-function runUseSub (signal: unknown, params?: unknown, options?: UseSubOptions): unknown {
-  if (isBatchBarrierCall(signal, params, options)) return closeBatchBarrier()
+function useNormalizedSub (signal: unknown, params?: unknown, options?: UseSubOptions): unknown {
+  const scheduleGroupUpdate = useSuspenseGroupScheduleUpdate()
+  if (isBatchBarrierCall(signal, params, options)) return closeBatchBarrier(scheduleGroupUpdate)
   if (USE_DEFERRED_VALUE) {
     return useSubDeferred(signal, params, options) // eslint-disable-line react-hooks/rules-of-hooks
   } else {
@@ -455,9 +457,14 @@ function isBatchBarrierCall (signal: unknown, params: unknown, options?: UseSubO
   return signal === undefined && params === undefined && !!options?.batch
 }
 
-function closeBatchBarrier (): void {
+function closeBatchBarrier (
+  scheduleGroupUpdate: ((promise: PromiseLike<unknown>) => void) | undefined
+): void {
   const promise = promiseBatcher.getPromiseAll()
-  if (promise) throw promise
+  if (promise) {
+    scheduleGroupUpdate?.(promise)
+    throw promise
+  }
 }
 
 // version of sub() which works as a react hook and throws promise for Suspense
@@ -468,6 +475,7 @@ export function useSubDeferred (
 ): unknown {
   const $signalRef = useRef<unknown>()
   const scheduleUpdate = useScheduleUpdate()
+  const scheduleGroupUpdate = useSuspenseGroupScheduleUpdate()
   const observerDefer = useDefer()
   if (batch) promiseBatcher.activate()
   defer ??= observerDefer ?? DEFAULT_DEFER
@@ -503,6 +511,7 @@ export function useSubDeferred (
       scheduleUpdate(promise)
       return $signalRef.current
     }
+    scheduleGroupUpdate?.(promise)
     throw promise
   // 2. if it's a signal, we save it into ref to make sure it's not garbage collected while component exists
   } else {
@@ -523,6 +532,7 @@ export function useSubClassic (
   const id = executionContextTracker.newHookId()
   const cache = useCache(undefined)
   const scheduleUpdate = useScheduleUpdate()
+  const scheduleGroupUpdate = useSuspenseGroupScheduleUpdate()
   if (batch) promiseBatcher.activate()
   const promiseOrSignal = params != null ? runtimeSub(signal, params) : runtimeSub(signal)
   // 1. if it's a promise, throw it so that Suspense can catch it and wait for subscription to finish
@@ -556,6 +566,7 @@ export function useSubClassic (
       // in regular mode we throw the promise to be caught by Suspense
       // this way we guarantee that the signal with all the data
       // will always be there when component is rendered
+      scheduleGroupUpdate?.(promise)
       throw promise
     }
     // if we already have a previous signal, we return it and wait for new promise to resolve

--- a/packages/teamplay/src/react/useSuspendMemo.ts
+++ b/packages/teamplay/src/react/useSuspendMemo.ts
@@ -1,6 +1,7 @@
 import executionContextTracker from './executionContextTracker.ts'
 import { useCache } from './helpers.ts'
 import renderAttemptDestroyer from './renderAttemptDestroyer.ts'
+import { useSuspenseGroupScheduleUpdate } from './wrapIntoSuspense.js'
 
 const IN_FLIGHT_BY_KEY = new Map<unknown, Promise<unknown>>()
 
@@ -19,6 +20,7 @@ export default function useSuspendMemo<TValue> (
   deps = normalizeDeps(deps)
 
   const cache = useCache(undefined)
+  const scheduleGroupUpdate = useSuspenseGroupScheduleUpdate()
   const hookId = executionContextTracker.newHookId()
   const cacheKey = `suspendMemo:${hookId}`
 
@@ -36,6 +38,7 @@ export default function useSuspendMemo<TValue> (
   if (entry.status === 'done') return entry.value as TValue
   if (entry.status === 'pending') {
     renderAttemptDestroyer.armSuspenseGate()
+    scheduleGroupUpdate?.(entry.promise as Promise<unknown>)
     throw entry.promise
   }
 
@@ -54,6 +57,7 @@ export default function useSuspendMemo<TValue> (
     entry.status = 'pending'
     entry.promise = promise
     renderAttemptDestroyer.armSuspenseGate()
+    scheduleGroupUpdate?.(promise)
     throw promise
   }
 }

--- a/packages/teamplay/src/react/wrapIntoSuspense.d.ts
+++ b/packages/teamplay/src/react/wrapIntoSuspense.d.ts
@@ -1,6 +1,13 @@
 import type * as React from 'react'
 import type { ConvertedObserver } from './convertToObserver.js'
 
+export declare function SuspenseGroup (props: {
+  children?: React.ReactNode
+  fallback?: React.ReactNode
+}): React.ReactElement
+
+export declare function useSuspenseGroupScheduleUpdate (): ((promise: PromiseLike<unknown>) => void) | undefined
+
 export interface WrapIntoSuspenseOptions<TProps extends object = Record<string, unknown>, TRef = unknown>
   extends ConvertedObserver<TProps, TRef> {}
 

--- a/packages/teamplay/src/react/wrapIntoSuspense.js
+++ b/packages/teamplay/src/react/wrapIntoSuspense.js
@@ -1,7 +1,64 @@
 // useSyncExternalStore is used to trigger an update same as in MobX
 // ref: https://github.com/mobxjs/mobx/blob/94bc4997c14152ff5aefcaac64d982d5c21ba51a/packages/mobx-react-lite/src/useObserver.ts
-import { useSyncExternalStore, forwardRef as _forwardRef, memo, createElement as el, Suspense, useId, useRef } from 'react'
+import {
+  useSyncExternalStore,
+  forwardRef as _forwardRef,
+  memo,
+  createContext,
+  createElement as el,
+  Suspense,
+  useContext,
+  useId,
+  useRef
+} from 'react'
 import { pipeComponentMeta, pipeComponentDisplayName, ComponentMetaContext } from './helpers.ts'
+
+const SuspenseGroupContext = createContext()
+
+export function SuspenseGroup ({ children, fallback = null }) {
+  const storeRef = useRef()
+  if (!storeRef.current) storeRef.current = createSuspenseGroupStore()
+  const store = storeRef.current
+
+  useSyncExternalStore(store.subscribe, store.getSnapshot, store.getSnapshot)
+
+  return el(
+    SuspenseGroupContext.Provider,
+    { value: store.scheduleUpdate },
+    el(Suspense, { fallback }, children)
+  )
+}
+
+export function useSuspenseGroupScheduleUpdate () {
+  return useContext(SuspenseGroupContext)
+}
+
+function createSuspenseGroupStore () {
+  let version = 0
+  const listeners = new Set()
+  const scheduled = new WeakSet()
+
+  return {
+    subscribe (listener) {
+      listeners.add(listener)
+      return () => listeners.delete(listener)
+    },
+    getSnapshot () {
+      return version
+    },
+    scheduleUpdate (promise) {
+      if (!promise?.then) throw Error('scheduleUpdate() expects a promise')
+      if (scheduled.has(promise)) return
+      scheduled.add(promise)
+
+      const retry = () => {
+        version++
+        for (const listener of listeners) listener()
+      }
+      promise.then(retry, retry)
+    }
+  }
+}
 
 // TODO: probably add FinalizationRegistry to handle destruction of observer() before it ever mounted.
 //       In such case we might have a memory leak because subscribe() would never fire and would never
@@ -23,6 +80,7 @@ export default function wrapIntoSuspense ({
   if (!suspenseProps?.fallback) throw Error(ERRORS.noFallback)
 
   let SuspenseWrapper = (props, ref) => {
+    const inheritsSuspense = !!useContext(SuspenseGroupContext)
     const componentId = useId()
     const componentMetaRef = useRef()
     const admRef = useRef()
@@ -90,13 +148,15 @@ export default function wrapIntoSuspense ({
 
     if (forwardRef) props = { ...props, ref }
 
-    return (
-      el(ComponentMetaContext.Provider, { value: componentMetaRef.current },
-        el(Suspense, suspenseProps,
-          el(Component, props)
-        )
-      )
+    const contents = el(
+      ComponentMetaContext.Provider,
+      { value: componentMetaRef.current },
+      el(Component, props)
     )
+    const hasCustomFallback = suspenseProps !== DEFAULT_SUSPENSE_PROPS
+    return inheritsSuspense && !hasCustomFallback
+      ? contents
+      : el(Suspense, suspenseProps, contents)
   }
 
   // pipe only displayName because forwardRef render function

--- a/packages/teamplay/test_client/35_suspense-group.js
+++ b/packages/teamplay/test_client/35_suspense-group.js
@@ -1,0 +1,219 @@
+import { createElement as el, Suspense } from 'react'
+import { afterEach, beforeAll, describe, expect, it } from '@jest/globals'
+import { act, cleanup, render, waitFor } from '@testing-library/react'
+import {
+  $,
+  observer,
+  SuspenseGroup,
+  useBatchSub,
+  useSub,
+  useSuspendMemo,
+  useSuspenseGroupScheduleUpdate
+} from '../src/index.ts'
+import connect from '../src/connect/test.js'
+import { runGc } from '../test/_helpers.js'
+
+beforeAll(connect)
+afterEach(cleanup)
+afterEach(runGc)
+
+describe('SuspenseGroup', () => {
+  it('keeps the default observer boundary unchanged outside a group', () => {
+    const blocker = new Promise(() => {})
+    const Child = observer(() => {
+      throw blocker
+    })
+
+    const { container } = render(
+      el(Suspense, {
+        fallback: el('div', { 'data-testid': 'outer-fallback' }, 'Outer')
+      }, el(Child))
+    )
+
+    expect(container.querySelector('[data-testid="outer-fallback"]')).toBeFalsy()
+    expect(container.textContent).toBe('')
+  })
+
+  it('retries suspended children when a registered promise settles', async () => {
+    const wake = deferred()
+    const blocker = new Promise(() => {})
+    let ready = false
+
+    const Child = observer(() => {
+      const scheduleUpdate = useSuspenseGroupScheduleUpdate()
+      scheduleUpdate(wake.promise)
+      if (!ready) throw blocker
+      return el('div', { 'data-testid': 'content' }, 'Ready')
+    })
+
+    const { container } = render(
+      el(SuspenseGroup, {
+        fallback: el('div', { 'data-testid': 'group-fallback' }, 'Loading')
+      }, el(Child))
+    )
+
+    expect(container.querySelector('[data-testid="group-fallback"]')).toBeTruthy()
+
+    await act(async () => {
+      ready = true
+      wake.resolve()
+      await wake.promise
+    })
+
+    await waitFor(() => {
+      expect(container.querySelector('[data-testid="content"]')).toBeTruthy()
+    })
+    expect(container.querySelector('[data-testid="group-fallback"]')).toBeFalsy()
+  })
+
+  it('groups an initial useSub subscription under the shared fallback', async () => {
+    const Child = observer(() => {
+      useSub($.suspenseGroupDoc.missing, { defer: false })
+      return el('div', { 'data-testid': 'document-content' }, 'Document ready')
+    })
+
+    const { container } = render(
+      el(SuspenseGroup, {
+        fallback: el('div', { 'data-testid': 'group-fallback' }, 'Loading')
+      }, el(Child))
+    )
+
+    expect(container.querySelector('[data-testid="group-fallback"]')).toBeTruthy()
+
+    await waitFor(() => {
+      expect(container.querySelector('[data-testid="document-content"]')).toBeTruthy()
+    })
+    expect(container.querySelector('[data-testid="group-fallback"]')).toBeFalsy()
+  })
+
+  it('groups a useBatchSub barrier under the shared fallback', async () => {
+    const Child = observer(() => {
+      useBatchSub($.suspenseGroupBatch.missing, { defer: false })
+      useBatchSub()
+      return el('div', { 'data-testid': 'batch-content' }, 'Batch ready')
+    })
+
+    const { container } = render(
+      el(SuspenseGroup, {
+        fallback: el('div', { 'data-testid': 'group-fallback' }, 'Loading')
+      }, el(Child))
+    )
+
+    expect(container.querySelector('[data-testid="group-fallback"]')).toBeTruthy()
+
+    await waitFor(() => {
+      expect(container.querySelector('[data-testid="batch-content"]')).toBeTruthy()
+    })
+    expect(container.querySelector('[data-testid="group-fallback"]')).toBeFalsy()
+  })
+
+  it('groups useSuspendMemo under the shared fallback', async () => {
+    const pending = deferred()
+    let ready = false
+    const Child = observer(() => {
+      useSuspendMemo(() => {
+        if (!ready) throw pending.promise
+      }, [])
+      return el('div', { 'data-testid': 'memo-content' }, 'Memo ready')
+    })
+
+    const { container } = render(
+      el(SuspenseGroup, {
+        fallback: el('div', { 'data-testid': 'group-fallback' }, 'Loading')
+      }, el(Child))
+    )
+
+    expect(container.querySelector('[data-testid="group-fallback"]')).toBeTruthy()
+
+    await act(async () => {
+      ready = true
+      pending.resolve()
+      await pending.promise
+    })
+
+    await waitFor(() => {
+      expect(container.querySelector('[data-testid="memo-content"]')).toBeTruthy()
+    })
+    expect(container.querySelector('[data-testid="group-fallback"]')).toBeFalsy()
+  })
+
+  it('does not suspend when a useSuspendMemo factory returns a Promise', () => {
+    const returnedPromise = Promise.resolve('value')
+    let memoValue
+    const Child = observer(() => {
+      memoValue = useSuspendMemo(() => returnedPromise, [])
+      return el('div', { 'data-testid': 'returned-promise-content' }, 'Rendered')
+    })
+
+    const { container } = render(
+      el(SuspenseGroup, {
+        fallback: el('div', { 'data-testid': 'group-fallback' }, 'Loading')
+      }, el(Child))
+    )
+
+    expect(memoValue).toBe(returnedPromise)
+    expect(container.querySelector('[data-testid="returned-promise-content"]')).toBeTruthy()
+    expect(container.querySelector('[data-testid="group-fallback"]')).toBeFalsy()
+  })
+
+  it('keeps an explicitly configured observer fallback', () => {
+    const blocker = new Promise(() => {})
+    const Child = observer(() => {
+      throw blocker
+    }, {
+      suspenseProps: {
+        fallback: el('div', { 'data-testid': 'custom-fallback' }, 'Custom')
+      }
+    })
+
+    const { container } = render(
+      el(SuspenseGroup, {
+        fallback: el('div', { 'data-testid': 'group-fallback' }, 'Group')
+      }, el(Child))
+    )
+
+    expect(container.querySelector('[data-testid="custom-fallback"]')).toBeTruthy()
+    expect(container.querySelector('[data-testid="group-fallback"]')).toBeFalsy()
+  })
+
+  it('retries when a registered promise rejects', async () => {
+    const wake = deferred()
+    const blocker = new Promise(() => {})
+    let ready = false
+
+    const Child = observer(() => {
+      const scheduleUpdate = useSuspenseGroupScheduleUpdate()
+      scheduleUpdate(wake.promise)
+      if (!ready) throw blocker
+      return el('div', { 'data-testid': 'recovered' }, 'Recovered')
+    })
+
+    const { container } = render(
+      el(SuspenseGroup, { fallback: el('div', {}, 'Loading') }, el(Child))
+    )
+
+    await act(async () => {
+      ready = true
+      wake.reject(new Error('expected test rejection'))
+      await Promise.resolve()
+    })
+
+    await waitFor(() => {
+      expect(container.querySelector('[data-testid="recovered"]')).toBeTruthy()
+    })
+  })
+})
+
+function deferred () {
+  let resolveDeferred
+  let rejectDeferred
+  const promise = new Promise((resolve, reject) => {
+    resolveDeferred = resolve
+    rejectDeferred = reject
+  })
+  return {
+    promise,
+    resolve: resolveDeferred,
+    reject: rejectDeferred
+  }
+}

--- a/packages/teamplay/test_types/external-consumer.ts
+++ b/packages/teamplay/test_types/external-consumer.ts
@@ -9,6 +9,7 @@ import $, {
   observer,
   reaction,
   setSubscriptionGcDelay,
+  SuspenseGroup,
   sub,
   useApi,
   useDidUpdate,
@@ -20,6 +21,7 @@ import $, {
   useSub,
   useSyncEffect,
   useSuspendMemo,
+  useSuspenseGroupScheduleUpdate,
   useTriggerUpdate,
   type FromJsonSchema,
   type JsonSchemaSpec,
@@ -110,6 +112,9 @@ const externalOrmReactionHandle: ReactionHandle = ormReaction(() => $user.age.ge
 externalOrmReactionHandle.dispose()
 
 function ExternalConsumerComponent () {
+  const suspenseGroupScheduleUpdate = useSuspenseGroupScheduleUpdate()
+  const optionalSuspenseGroupScheduleUpdate:
+    ((promise: PromiseLike<unknown>) => void) | undefined = suspenseGroupScheduleUpdate
   const maybeHookUser = useSub(typedUserSignal)
   type _useSubResult = Assert<IsEqual<typeof maybeHookUser, Signal<UserDoc>>>
 
@@ -152,7 +157,14 @@ function ExternalConsumerComponent () {
     nextGcDelay
   ])
 
+  optionalSuspenseGroupScheduleUpdate?.(Promise.resolve())
+
   return React.createElement(ObservedUser, { name: 'Ada' })
 }
 
 React.createElement(ExternalConsumerComponent)
+React.createElement(
+  SuspenseGroup,
+  { fallback: React.createElement('span', null, 'Loading') },
+  React.createElement(ExternalConsumerComponent)
+)


### PR DESCRIPTION
## Summary

- add an opt-in `SuspenseGroup` boundary that consolidates the default Suspense boundaries created by nested `observer()` components
- schedule immediate group retries for initial `useSub()`, the closing `useBatchSub()` barrier, and `useSuspendMemo()` promises
- expose `useSuspenseGroupScheduleUpdate()` for stable promises created outside TeamPlay, such as memoized `React.lazy()` loaders
- preserve explicit observer fallbacks and all behavior outside a group
- document the grouped-boundary contract and the correct `useSuspendMemo()` mental model

## Why

React 19 throttles successive Suspense fallback commits in 300 ms windows. In a real StartupJS player route, fast ShareDB subscriptions therefore became multiple visible render waves even though each local transport response took only a few milliseconds.

The group owns one external-store retry coordinator. When any registered promise settles, it retries the suspended subtree through an ordinary React update instead of waiting for another nested retry window. It uses only public React APIs and remains opt-in.

Downstream React 19 production-mode measurements with cold browser contexts:

| Route | TeamPlay 0.5.2 | Grouped retries | Change |
| --- | ---: | ---: | ---: |
| Survey | 993 ms | 669 ms | -324 ms (-33%) |
| Debrief | 1,237-1,256 ms | 687 ms | -550 to -569 ms (-44% to -45%) |

## Compatibility

- default `observer()` boundaries are consolidated only under `SuspenseGroup`
- an observer configured with an explicit `suspenseProps.fallback` retains its local boundary
- `useAsyncSub()` and update re-subscriptions retain their existing non-suspending behavior
- nested code outside a group behaves exactly as before
- the API and generated `dist` declarations are checked from an external TypeScript consumer

## Validation

- 8 focused `SuspenseGroup` integration tests pass, covering direct scheduling, `useSub`, `useBatchSub`, `useSuspendMemo`, rejection, explicit fallback preservation, and the unchanged outside-group contract
- full React client suite: 5 suites, 111 tests pass
- Babel plugin: 30 tests pass
- source, external-consumer, and built-`dist` type checks pass
- package build, docs build, lint, and `git diff --check` pass
- downstream LMS: 840 unit tests pass, 1 skipped; production bundle contract and authenticated Survey/Debrief smoke pass without page errors

## Known baseline flake

The complete server run executes 438 passing tests with 4 pending, then intermittently fails an existing `root finalization` afterEach invariant (`null` runtime query view versus `undefined` canonical entry). The isolated `rootFinalization` suite passes 7/7. This PR changes only React integration code and does not touch query or root cleanup.
