### PR TITLE
Fix useSub subscription ownership lifecycle

### DIFF
--- a/architecture.md
+++ b/architecture.md
@@ -449,6 +449,14 @@ React subscriptions must preserve the same runtime signal shapes as `sub()`:
 
 When changing React behavior, check both runtime correctness and end-user ergonomics: suspense timing, stable signal identity, cleanup, and editor-visible result types.
 
+`useSub()` keeps one component-owned subscription lease per hook and stable
+signal/query arguments. The component metadata cache preserves that lease across
+Suspense retries, committed effects release it on unmount, and a replacement
+lease keeps the previous snapshot alive until the replacement is ready.
+Uncommitted render attempts receive a bounded cleanup grace after their
+readiness promise settles, so abandoned Suspense work cannot retain owners
+indefinitely.
+
 ## Backend Features
 
 The backend layer starts in [packages/backend/index.js](./packages/backend/index.js). It composes ShareDB with TeamPlay-specific server features.

--- a/architecture.md
+++ b/architecture.md
@@ -453,9 +453,12 @@ When changing React behavior, check both runtime correctness and end-user ergono
 signal/query arguments. The component metadata cache preserves that lease across
 Suspense retries, committed effects release it on unmount, and a replacement
 lease keeps the previous snapshot alive until the replacement is ready.
-Uncommitted render attempts receive a bounded cleanup grace after their
-readiness promise settles, so abandoned Suspense work cannot retain owners
-indefinitely.
+The outer observer cache also owns pending leases, so unmounting a Suspense
+fallback can cancel subscription ownership before the transport becomes ready.
+For batches, abandoned-render cleanup waits for the complete batch barrier
+rather than an individual query; incomplete render attempts fall back to the
+individual readiness promise. Cleanup is deferred by one task so React
+StrictMode subscription replay does not look like a real unmount.
 
 ## Backend Features
 

--- a/packages/teamplay/src/orm/sub.ts
+++ b/packages/teamplay/src/orm/sub.ts
@@ -40,6 +40,11 @@ interface SubRecord {
 }
 
 const SUB_RECORDS = new WeakMap<SignalBaseInstance, SubRecord[]>()
+const SUB_RESULT_SIGNAL = Symbol('sub result signal')
+
+interface PendingSubResult extends Promise<SignalBaseInstance> {
+  [SUB_RESULT_SIGNAL]?: SignalBaseInstance
+}
 
 /**
  * Subscribe to an aggregation with explicit output typing outside React.
@@ -183,6 +188,18 @@ export function unsub ($signal: unknown): Promise<void> | void {
   if (!($signal instanceof Signal)) return
   const record = takeSubRecord($signal)
   if (!record) return
+  return disposeSubRecord($signal, record)
+}
+
+// React leases must be able to release ownership while the transport promise is still pending.
+export function getSubResultSignal (result: unknown): SignalBaseInstance | undefined {
+  if (result instanceof Signal) return result
+  if (!result || (typeof result !== 'object' && typeof result !== 'function')) return
+  return (result as PendingSubResult)[SUB_RESULT_SIGNAL]
+}
+
+function disposeSubRecord ($signal: SignalBaseInstance, record: SubRecord): Promise<void> | void {
+  if (record.disposed) return
   record.disposed = true
 
   const $root = getRoot($signal)
@@ -306,23 +323,33 @@ function returnSubscribedSignal (
   intent: SubIntent,
   promise?: Promise<void> | void
 ): SignalBaseInstance | Promise<SignalBaseInstance> {
+  const record = addSubRecord($signal, kind, intent)
   if (!promise) {
-    addSubRecord($signal, kind, intent)
     return $signal
   }
-  return promise.then(() => {
-    addSubRecord($signal, kind, intent)
-    return $signal
-  })
+  const result = Promise.resolve(promise).then(
+    () => $signal,
+    err => {
+      const pendingCleanup = takeSpecificSubRecord($signal, record)
+      if (pendingCleanup) {
+        Promise.resolve(disposeSubRecord($signal, pendingCleanup)).catch(ignoreSubCleanupError)
+      }
+      throw err
+    }
+  ) as PendingSubResult
+  Object.defineProperty(result, SUB_RESULT_SIGNAL, { value: $signal })
+  return result
 }
 
-function addSubRecord ($signal: SignalBaseInstance, kind: SubRecordKind, intent: SubIntent): void {
+function addSubRecord ($signal: SignalBaseInstance, kind: SubRecordKind, intent: SubIntent): SubRecord {
   let records = SUB_RECORDS.get($signal)
   if (!records) {
     records = []
     SUB_RECORDS.set($signal, records)
   }
-  records.push({ kind, intent, disposed: false })
+  const record = { kind, intent, disposed: false }
+  records.push(record)
+  return record
 }
 
 function takeSubRecord ($signal: SignalBaseInstance): SubRecord | undefined {
@@ -337,6 +364,21 @@ function takeSubRecord ($signal: SignalBaseInstance): SubRecord | undefined {
   }
   SUB_RECORDS.delete($signal)
 }
+
+function takeSpecificSubRecord (
+  $signal: SignalBaseInstance,
+  target: SubRecord
+): SubRecord | undefined {
+  const records = SUB_RECORDS.get($signal)
+  if (!records) return
+  const index = records.lastIndexOf(target)
+  if (index === -1) return
+  records.splice(index, 1)
+  if (records.length === 0) SUB_RECORDS.delete($signal)
+  return target
+}
+
+function ignoreSubCleanupError (): void {}
 
 const ERRORS = {
   subDocArguments: ($signal: SignalBaseInstance, ...args: unknown[]) => `

--- a/packages/teamplay/src/react/helpers.ts
+++ b/packages/teamplay/src/react/helpers.ts
@@ -5,6 +5,8 @@ export interface ComponentMetaCache {
   get: (key: unknown) => unknown
   set: (key: unknown, value: unknown) => unknown
   has: (key: unknown) => boolean
+  /** Register cleanup owned by the observer wrapper, including suspended children. */
+  onDestroy: (cleanup: () => void) => () => void
 }
 
 export interface ComponentMeta {

--- a/packages/teamplay/src/react/promiseBatcher.ts
+++ b/packages/teamplay/src/react/promiseBatcher.ts
@@ -1,6 +1,7 @@
 let active = false
 let promises: Array<PromiseLike<unknown>> = []
 let checks = new Map<unknown, BatchReadinessCheck>()
+let renderAttemptCleanups: RenderAttemptCleanup[] = []
 
 const READINESS_POLL_INTERVAL_MS = 16
 const READINESS_WARN_AFTER_MS = 1000
@@ -12,6 +13,8 @@ export interface BatchReadinessCheck {
   isReady: () => boolean
   getState?: () => unknown
 }
+
+type RenderAttemptCleanup = (barrier: PromiseLike<void> | null) => void
 
 export function activate (): void {
   active = true
@@ -28,9 +31,14 @@ export function addCheck (check: BatchReadinessCheck | null | undefined): void {
   checks.set(key, { ...check, key })
 }
 
+export function addRenderAttemptCleanup (cleanup: RenderAttemptCleanup): void {
+  renderAttemptCleanups.push(cleanup)
+}
+
 export function getPromiseAll (): Promise<void> | null {
   const pendingPromises = promises
   const pendingChecks = Array.from(checks.values())
+  const pendingCleanups = renderAttemptCleanups
   const hasPromises = pendingPromises.length > 0
   // Checks are a materialization barrier for initial batch subscriptions.
   // If there were no subscription promises in this render, we are in update mode
@@ -39,6 +47,7 @@ export function getPromiseAll (): Promise<void> | null {
     ? waitForBatchReady(pendingPromises, pendingChecks)
     : null
   reset()
+  runRenderAttemptCleanups(pendingCleanups, result)
   return result
 }
 
@@ -50,6 +59,20 @@ export function reset (): void {
   active = false
   promises = []
   checks = new Map()
+  renderAttemptCleanups = []
+}
+
+export function abort (): void {
+  const pendingCleanups = renderAttemptCleanups
+  reset()
+  runRenderAttemptCleanups(pendingCleanups, null)
+}
+
+function runRenderAttemptCleanups (
+  cleanups: RenderAttemptCleanup[],
+  barrier: PromiseLike<void> | null
+): void {
+  for (const cleanup of cleanups) cleanup(barrier)
 }
 
 async function waitForBatchReady (

--- a/packages/teamplay/src/react/trapRender.js
+++ b/packages/teamplay/src/react/trapRender.js
@@ -18,7 +18,7 @@ export default function trapRender ({ render, cache, destroy, componentId }) {
       }
       return res
     } catch (err) {
-      promiseBatcher.reset()
+      promiseBatcher.abort()
       if (!err.then) {
         destroy('trapRender.js')
         destroyed = true

--- a/packages/teamplay/src/react/useSub.ts
+++ b/packages/teamplay/src/react/useSub.ts
@@ -1,6 +1,6 @@
-import { useRef, useDeferredValue } from 'react'
+import { useEffect, useRef, useDeferredValue } from 'react'
 import type { AggregationFunction, AggregationParams, ClientAggregationFunction } from '@teamplay/utils/aggregation'
-import sub from '../orm/sub.ts'
+import sub, { unsub } from '../orm/sub.ts'
 import { useScheduleUpdate, useCache, useDefer } from './helpers.ts'
 import { useSuspenseGroupScheduleUpdate } from './wrapIntoSuspense.js'
 import executionContextTracker from './executionContextTracker.ts'
@@ -19,6 +19,7 @@ import {
 } from '../orm/Query.js'
 import { AGGREGATIONS, IS_AGGREGATION, aggregationSubscriptions } from '../orm/Aggregation.js'
 import { SEGMENTS } from '../orm/signalSymbols.ts'
+import { getSubscriptionGcDelay } from '../orm/subscriptionGcDelay.ts'
 import {
   isPublicDocumentSignal,
   type CollectionSignal,
@@ -47,6 +48,7 @@ export interface UseSubOptions {
 }
 
 const USE_SUB_OPTION_KEYS = new Set<string>(['async', 'defer', 'batch'] satisfies Array<keyof UseSubOptions>)
+const MAX_UNCOMMITTED_LEASE_GRACE_MS = 50
 
 let TEST_THROTTLING: false | number = false
 
@@ -484,11 +486,13 @@ export function useSubDeferred (
     const serializedParams = useDeferredValue(params ? JSON.stringify(params) : undefined) // eslint-disable-line react-hooks/rules-of-hooks
     params = serializedParams != null ? JSON.parse(serializedParams) : undefined
   }
-  const promiseOrSignal = params != null ? runtimeSub(signal, params) : runtimeSub(signal)
+  const subscriptionLease = useSubscriptionLease(signal, params)
+  const promiseOrSignal = subscriptionLease.value
   // 1. if it's a promise, throw it so that Suspense can catch it and wait for subscription to finish
   if (isThenable(promiseOrSignal)) {
     const promise = maybeThrottle(promiseOrSignal)
     const readyPromise = batch ? getBatchReadyPromise(promise) : promise
+    scheduleUncommittedLeaseCleanupAfter(subscriptionLease, readyPromise)
     const hasPreviousSignal = !!$signalRef.current
     if (batch) {
       // Batch suspense must block only on initial load.
@@ -534,11 +538,13 @@ export function useSubClassic (
   const scheduleUpdate = useScheduleUpdate()
   const scheduleGroupUpdate = useSuspenseGroupScheduleUpdate()
   if (batch) promiseBatcher.activate()
-  const promiseOrSignal = params != null ? runtimeSub(signal, params) : runtimeSub(signal)
+  const subscriptionLease = useSubscriptionLease(signal, params)
+  const promiseOrSignal = subscriptionLease.value
   // 1. if it's a promise, throw it so that Suspense can catch it and wait for subscription to finish
   if (isThenable(promiseOrSignal)) {
     const promise = maybeThrottle(promiseOrSignal)
     const readyPromise = batch ? getBatchReadyPromise(promise) : promise
+    scheduleUncommittedLeaseCleanupAfter(subscriptionLease, readyPromise)
     if (batch) {
       const hasPreviousSignal = cache.has(id)
       // Batch suspense must block only on initial load.
@@ -598,6 +604,145 @@ export function setUseDeferredValue (value: boolean): void {
 export function setDefaultDefer (value: boolean): void {
   DEFAULT_DEFER = value
 }
+
+interface SubscriptionLease {
+  value: unknown
+  signal?: unknown
+  inputSignal?: unknown
+  serializedParams?: string
+  previousLease?: SubscriptionLease
+  committed: boolean
+  released: boolean
+  cleanupTimer?: ReturnType<typeof setTimeout>
+  releaseTimer?: ReturnType<typeof setTimeout>
+}
+
+function useSubscriptionLease (signal: unknown, params?: unknown): SubscriptionLease {
+  const cache = useCache(undefined)
+  const hookId = executionContextTracker.newHookId()
+  const cacheKey = `subscriptionLease:${hookId}`
+  const serializedParams = params != null ? JSON.stringify(params) : undefined
+  let lease = cache.get(cacheKey) as SubscriptionLease | undefined
+  if (
+    !lease ||
+    lease.released ||
+    lease.inputSignal !== signal ||
+    lease.serializedParams !== serializedParams
+  ) {
+    lease = createSubscriptionLease(signal, params, serializedParams, lease)
+    cache.set(cacheKey, lease)
+  }
+
+  useEffect(() => {
+    lease.committed = true
+    clearTimeout(lease.cleanupTimer)
+    lease.cleanupTimer = undefined
+    clearTimeout(lease.releaseTimer)
+    lease.releaseTimer = undefined
+    if (lease.previousLease) {
+      clearTimeout(lease.previousLease.releaseTimer)
+      lease.previousLease.releaseTimer = undefined
+    }
+    return () => scheduleSubscriptionLeaseRelease(lease)
+  }, [lease])
+
+  useEffect(() => {
+    if (isThenable(lease.value)) return
+    releasePreviousSubscriptionLease(lease)
+  })
+
+  return lease
+}
+
+function createSubscriptionLease (
+  signal: unknown,
+  params: unknown,
+  serializedParams?: string,
+  previousLease?: SubscriptionLease
+): SubscriptionLease {
+  const value = params != null ? runtimeSub(signal, params) : runtimeSub(signal)
+  const lease: SubscriptionLease = {
+    value,
+    signal: isThenable(value) ? undefined : value,
+    inputSignal: signal,
+    serializedParams,
+    previousLease: previousLease?.released ? undefined : previousLease,
+    committed: false,
+    released: false
+  }
+
+  if (isThenable(value)) {
+    Promise.resolve(value).then($signal => {
+      lease.signal = $signal
+      lease.value = $signal
+      if (lease.released) {
+        disposeSubscriptionLeaseSignal(lease)
+      }
+    }, ignoreSubscriptionCleanupError)
+  } else {
+    scheduleUncommittedLeaseCleanup(lease)
+  }
+
+  return lease
+}
+
+function scheduleUncommittedLeaseCleanupAfter (
+  lease: SubscriptionLease,
+  promise: PromiseLike<unknown>
+): void {
+  Promise.resolve(promise).then(
+    () => scheduleUncommittedLeaseCleanup(lease),
+    () => scheduleUncommittedLeaseCleanup(lease)
+  )
+}
+
+function scheduleUncommittedLeaseCleanup (lease: SubscriptionLease): void {
+  if (lease.committed || lease.released || lease.cleanupTimer) return
+  lease.cleanupTimer = setTimeout(() => {
+    lease.cleanupTimer = undefined
+    if (!lease.committed) releaseSubscriptionLease(lease)
+  }, Math.min(getSubscriptionGcDelay(), MAX_UNCOMMITTED_LEASE_GRACE_MS))
+}
+
+function releaseSubscriptionLease (lease: SubscriptionLease): void {
+  if (lease.released) return
+  const previousLease = lease.previousLease
+  lease.previousLease = undefined
+  lease.released = true
+  clearTimeout(lease.cleanupTimer)
+  lease.cleanupTimer = undefined
+  clearTimeout(lease.releaseTimer)
+  lease.releaseTimer = undefined
+  disposeSubscriptionLeaseSignal(lease)
+  if (lease.committed && previousLease) releaseSubscriptionLease(previousLease)
+}
+
+function releasePreviousSubscriptionLease (lease: SubscriptionLease): void {
+  const previousLease = lease.previousLease
+  if (!previousLease) return
+  lease.previousLease = undefined
+  releaseSubscriptionLease(previousLease)
+}
+
+function scheduleSubscriptionLeaseRelease (lease: SubscriptionLease): void {
+  if (lease.released || lease.releaseTimer) return
+  lease.releaseTimer = setTimeout(() => {
+    lease.releaseTimer = undefined
+    releaseSubscriptionLease(lease)
+  })
+}
+
+function disposeSubscriptionLeaseSignal (lease: SubscriptionLease): void {
+  const signal = lease.signal
+  lease.signal = undefined
+  lease.inputSignal = undefined
+  lease.serializedParams = undefined
+  lease.value = undefined
+  if (!signal) return
+  Promise.resolve(unsub(signal)).catch(ignoreSubscriptionCleanupError)
+}
+
+function ignoreSubscriptionCleanupError (): void {}
 
 // throttle to simulate slow network
 function maybeThrottle<TValue> (promise: Promise<TValue>): Promise<TValue> {

--- a/packages/teamplay/src/react/useSub.ts
+++ b/packages/teamplay/src/react/useSub.ts
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useDeferredValue } from 'react'
 import type { AggregationFunction, AggregationParams, ClientAggregationFunction } from '@teamplay/utils/aggregation'
-import sub, { unsub } from '../orm/sub.ts'
+import sub, { getSubResultSignal, unsub } from '../orm/sub.ts'
 import { useScheduleUpdate, useCache, useDefer } from './helpers.ts'
 import { useSuspenseGroupScheduleUpdate } from './wrapIntoSuspense.js'
 import executionContextTracker from './executionContextTracker.ts'
@@ -492,7 +492,7 @@ export function useSubDeferred (
   if (isThenable(promiseOrSignal)) {
     const promise = maybeThrottle(promiseOrSignal)
     const readyPromise = batch ? getBatchReadyPromise(promise) : promise
-    scheduleUncommittedLeaseCleanupAfter(subscriptionLease, readyPromise)
+    scheduleRenderAttemptLeaseCleanup(subscriptionLease, readyPromise, batch)
     const hasPreviousSignal = !!$signalRef.current
     if (batch) {
       // Batch suspense must block only on initial load.
@@ -520,6 +520,7 @@ export function useSubDeferred (
   // 2. if it's a signal, we save it into ref to make sure it's not garbage collected while component exists
   } else {
     const $signal = promiseOrSignal
+    scheduleRenderAttemptLeaseCleanup(subscriptionLease, Promise.resolve(), batch)
     if (batch && !$signalRef.current) addBatchReadinessCheckForSignal($signal)
     if ($signalRef.current !== $signal) $signalRef.current = $signal
     return $signal
@@ -544,7 +545,7 @@ export function useSubClassic (
   if (isThenable(promiseOrSignal)) {
     const promise = maybeThrottle(promiseOrSignal)
     const readyPromise = batch ? getBatchReadyPromise(promise) : promise
-    scheduleUncommittedLeaseCleanupAfter(subscriptionLease, readyPromise)
+    scheduleRenderAttemptLeaseCleanup(subscriptionLease, readyPromise, batch)
     if (batch) {
       const hasPreviousSignal = cache.has(id)
       // Batch suspense must block only on initial load.
@@ -581,6 +582,7 @@ export function useSubClassic (
   // 2. if it's a signal, we save it into ref to make sure it's not garbage collected while component exists
   } else {
     const $signal = promiseOrSignal
+    scheduleRenderAttemptLeaseCleanup(subscriptionLease, Promise.resolve(), batch)
     if (batch && !cache.has(id)) addBatchReadinessCheckForSignal($signal)
     if (cache.get(id) !== $signal) {
       cache.set(id, $signal)
@@ -615,6 +617,7 @@ interface SubscriptionLease {
   released: boolean
   cleanupTimer?: ReturnType<typeof setTimeout>
   releaseTimer?: ReturnType<typeof setTimeout>
+  unregisterCacheDestroy?: () => void
 }
 
 function useSubscriptionLease (signal: unknown, params?: unknown): SubscriptionLease {
@@ -629,8 +632,10 @@ function useSubscriptionLease (signal: unknown, params?: unknown): SubscriptionL
     lease.inputSignal !== signal ||
     lease.serializedParams !== serializedParams
   ) {
-    lease = createSubscriptionLease(signal, params, serializedParams, lease)
-    cache.set(cacheKey, lease)
+    const nextLease = createSubscriptionLease(signal, params, serializedParams, lease)
+    nextLease.unregisterCacheDestroy = cache.onDestroy(() => releaseSubscriptionLease(nextLease))
+    lease = nextLease
+    cache.set(cacheKey, nextLease)
   }
 
   useEffect(() => {
@@ -663,7 +668,7 @@ function createSubscriptionLease (
   const value = params != null ? runtimeSub(signal, params) : runtimeSub(signal)
   const lease: SubscriptionLease = {
     value,
-    signal: isThenable(value) ? undefined : value,
+    signal: getSubResultSignal(value),
     inputSignal: signal,
     serializedParams,
     previousLease: previousLease?.released ? undefined : previousLease,
@@ -679,8 +684,6 @@ function createSubscriptionLease (
         disposeSubscriptionLeaseSignal(lease)
       }
     }, ignoreSubscriptionCleanupError)
-  } else {
-    scheduleUncommittedLeaseCleanup(lease)
   }
 
   return lease
@@ -696,6 +699,20 @@ function scheduleUncommittedLeaseCleanupAfter (
   )
 }
 
+function scheduleRenderAttemptLeaseCleanup (
+  lease: SubscriptionLease,
+  readyPromise: PromiseLike<unknown>,
+  batch: boolean
+): void {
+  if (!batch) {
+    scheduleUncommittedLeaseCleanupAfter(lease, readyPromise)
+    return
+  }
+  promiseBatcher.addRenderAttemptCleanup(barrier => {
+    scheduleUncommittedLeaseCleanupAfter(lease, barrier ?? readyPromise)
+  })
+}
+
 function scheduleUncommittedLeaseCleanup (lease: SubscriptionLease): void {
   if (lease.committed || lease.released || lease.cleanupTimer) return
   lease.cleanupTimer = setTimeout(() => {
@@ -709,6 +726,8 @@ function releaseSubscriptionLease (lease: SubscriptionLease): void {
   const previousLease = lease.previousLease
   lease.previousLease = undefined
   lease.released = true
+  lease.unregisterCacheDestroy?.()
+  lease.unregisterCacheDestroy = undefined
   clearTimeout(lease.cleanupTimer)
   lease.cleanupTimer = undefined
   clearTimeout(lease.releaseTimer)

--- a/packages/teamplay/src/react/wrapIntoSuspense.js
+++ b/packages/teamplay/src/react/wrapIntoSuspense.js
@@ -64,11 +64,21 @@ function createSuspenseGroupStore () {
 //       In such case we might have a memory leak because subscribe() would never fire and would never
 //       clean up the cache
 function destroyAdm (adm) {
+  clearTimeout(adm.destroyTimer)
+  adm.destroyTimer = undefined
+  for (const cleanup of Array.from(adm.cacheDestroyCallbacks || [])) cleanup()
+  adm.cacheDestroyCallbacks?.clear()
   adm.onStoreChange = undefined
   adm.scheduledUpdatePromise = undefined
   adm.scheduleUpdate = undefined
   adm.cache?.clear()
+  adm.cacheDestroyCallbacks = undefined
   adm.cache = undefined
+}
+
+function scheduleDestroyAdm (adm) {
+  if (adm.destroyTimer) return
+  adm.destroyTimer = setTimeout(() => destroyAdm(adm))
 }
 
 export default function wrapIntoSuspense ({
@@ -89,8 +99,10 @@ export default function wrapIntoSuspense ({
         stateVersion: Symbol(), // eslint-disable-line symbol-description
         onStoreChange: undefined,
         scheduledUpdatePromise: undefined,
+        destroyTimer: undefined,
         hasPendingUpdate: false,
         cache: new Map(),
+        cacheDestroyCallbacks: new Set(),
         scheduleUpdate: promise => {
           if (!promise?.then) throw Error('scheduleUpdate() expects a promise')
           if (adm.scheduledUpdatePromise === promise) return
@@ -102,6 +114,8 @@ export default function wrapIntoSuspense ({
           })
         },
         subscribe (onStoreChange) {
+          clearTimeout(adm.destroyTimer)
+          adm.destroyTimer = undefined
           adm.onStoreChange = () => {
             adm.stateVersion = Symbol() // eslint-disable-line symbol-description
             onStoreChange()
@@ -112,7 +126,7 @@ export default function wrapIntoSuspense ({
             adm.hasPendingUpdate = false
             queueMicrotask(() => adm.onStoreChange?.())
           }
-          return () => destroyAdm(adm)
+          return () => scheduleDestroyAdm(adm)
         },
         getSnapshot () {
           return adm.stateVersion
@@ -141,7 +155,13 @@ export default function wrapIntoSuspense ({
         cache: {
           get: key => adm.cache?.get(key),
           set: (key, value) => adm.cache?.set(key, value),
-          has: key => adm.cache?.has(key)
+          has: key => adm.cache?.has(key),
+          onDestroy: cleanup => {
+            adm.cacheDestroyCallbacks?.add(cleanup)
+            return () => {
+              adm.cacheDestroyCallbacks?.delete(cleanup)
+            }
+          }
         }
       }
     }

--- a/packages/teamplay/test/_helpers.js
+++ b/packages/teamplay/test/_helpers.js
@@ -3,6 +3,7 @@ import { strict as assert } from 'node:assert'
 import { __DEBUG_SIGNALS_CACHE__ as signalsCache } from '../src/index.ts'
 import { docSubscriptions } from '../src/orm/Doc.js'
 import { querySubscriptions } from '../src/orm/Query.js'
+import { aggregationSubscriptions } from '../src/orm/Aggregation.js'
 import { getSubscriptionGcDelay, setSubscriptionGcDelay } from '../src/orm/subscriptionGcDelay.ts'
 
 // the cache is not getting cleared if we just call global.gc()
@@ -35,6 +36,7 @@ export async function runGc (iterations = GC_ITERATIONS) {
       await delay()
       await docSubscriptions.flushPendingDestroys()
       await querySubscriptions.flushPendingDestroys()
+      await aggregationSubscriptions.flushPendingDestroys()
     }
     // Finalizers are not guaranteed to run in the same turn. Do two extra settle cycles
     // while delay=0 so late GC callbacks don't leave pending destroy timers.
@@ -44,6 +46,7 @@ export async function runGc (iterations = GC_ITERATIONS) {
       await delay()
       await docSubscriptions.flushPendingDestroys()
       await querySubscriptions.flushPendingDestroys()
+      await aggregationSubscriptions.flushPendingDestroys()
     }
   } finally {
     setSubscriptionGcDelay(prevSubscriptionGcDelay)

--- a/packages/teamplay/test_client/40_use-sub-lifecycle.js
+++ b/packages/teamplay/test_client/40_use-sub-lifecycle.js
@@ -1,0 +1,182 @@
+import { createElement as el, StrictMode, Suspense } from 'react'
+import { afterEach, beforeAll, beforeEach, describe, expect, it } from '@jest/globals'
+import { act, cleanup, render, waitFor } from '@testing-library/react'
+import { getRootSignal, observer, useBatchSub } from '../src/index.ts'
+import { querySubscriptions } from '../src/orm/Query.js'
+import { aggregationSubscriptions } from '../src/orm/Aggregation.js'
+import {
+  getSubscriptionGcDelay,
+  setSubscriptionGcDelay
+} from '../src/orm/subscriptionGcDelay.ts'
+import {
+  resetTestThrottling,
+  setTestThrottling
+} from '../src/react/useSub.ts'
+import connect from '../src/connect/test.js'
+
+beforeAll(connect)
+
+const baselineGcDelay = getSubscriptionGcDelay()
+const $testRoot = getRootSignal({ rootId: 'use-sub-lifecycle-tests' })
+
+beforeEach(async () => {
+  setSubscriptionGcDelay(20)
+  await querySubscriptions.clear()
+  await aggregationSubscriptions.clear()
+})
+
+afterEach(cleanup)
+afterEach(async () => {
+  resetTestThrottling()
+  await querySubscriptions.clear()
+  await aggregationSubscriptions.clear()
+  setSubscriptionGcDelay(baselineGcDelay)
+})
+
+describe('useSub subscription ownership', () => {
+  it('acquires a query only once across ordinary rerenders', async () => {
+    const Component = createQueryComponent('rerender')
+    const view = render(el(Component, { renderId: 0 }))
+
+    await waitForContent(view.container, 'render-0')
+    await waitForLeaseCleanup()
+
+    for (let renderId = 1; renderId <= 10; renderId++) {
+      view.rerender(el(Component, { renderId }))
+    }
+    await waitForContent(view.container, 'render-10')
+    await waitForLeaseCleanup()
+
+    expect(sum(querySubscriptions.ownerSubscribeCount.values())).toBe(1)
+    expect(querySubscriptions.queries.size).toBe(1)
+  })
+
+  it('releases query ownership on every unmount without waiting for GC', async () => {
+    const Component = createQueryComponent('mount-cycle')
+
+    for (let mountId = 0; mountId < 5; mountId++) {
+      const view = render(el(Component, { renderId: mountId }))
+      await waitForContent(view.container, `render-${mountId}`)
+      view.unmount()
+      await waitForLeaseCleanup()
+    }
+
+    expect(querySubscriptions.ownerMeta.size).toBe(0)
+    expect(querySubscriptions.queries.size).toBe(0)
+    expect(sum(querySubscriptions.ownerSubscribeCount.values())).toBe(0)
+  })
+
+  it('releases batched aggregation ownership across repeated page unmounts', async () => {
+    for (let mountId = 0; mountId < 5; mountId++) {
+      const view = render(el(BatchedAggregationPage, { mountId }))
+      await waitForContent(view.container, `page-${mountId}`)
+      view.unmount()
+      await waitForLeaseCleanup()
+    }
+
+    expect(aggregationSubscriptions.ownerMeta.size).toBe(0)
+    expect(aggregationSubscriptions.queries.size).toBe(0)
+    expect(sum(aggregationSubscriptions.ownerSubscribeCount.values())).toBe(0)
+  })
+
+  it('keeps its subscription through StrictMode effect replay', async () => {
+    const Component = createQueryComponent('strict-mode')
+    const view = render(el(StrictMode, {}, el(Component, { renderId: 1 })))
+
+    await waitForContent(view.container, 'render-1')
+    await waitForLeaseCleanup()
+    expect(sum(querySubscriptions.ownerSubscribeCount.values())).toBe(1)
+    expect(querySubscriptions.queries.size).toBe(1)
+
+    view.unmount()
+    await waitForLeaseCleanup()
+    expect(querySubscriptions.ownerMeta.size).toBe(0)
+    expect(querySubscriptions.queries.size).toBe(0)
+  })
+
+  it('keeps a shared query until its final component owner unmounts', async () => {
+    const QueryComponent = createQueryComponent('shared')
+    const view = render(el(SharedQueries, { QueryComponent, second: true }))
+
+    await waitForContent(view.container, 'render-1render-2')
+    await waitForLeaseCleanup()
+    expect(sum(querySubscriptions.ownerSubscribeCount.values())).toBe(2)
+    expect(querySubscriptions.queries.size).toBe(1)
+
+    view.rerender(el(SharedQueries, { QueryComponent, second: false }))
+    await waitForContent(view.container, 'render-1')
+    await waitForLeaseCleanup()
+    expect(sum(querySubscriptions.ownerSubscribeCount.values())).toBe(1)
+    expect(querySubscriptions.queries.size).toBe(1)
+
+    view.unmount()
+    await waitForLeaseCleanup()
+    expect(querySubscriptions.ownerMeta.size).toBe(0)
+    expect(querySubscriptions.queries.size).toBe(0)
+  })
+
+  it('releases a subscription from an abandoned Suspense render', async () => {
+    setTestThrottling(100)
+    const Component = createQueryComponent('abandoned')
+    const view = render(
+      el(Suspense, { fallback: el('span', {}, 'Loading') }, el(Component, { renderId: 1 }))
+    )
+
+    await waitFor(() => {
+      expect(sum(querySubscriptions.ownerSubscribeCount.values())).toBeGreaterThan(0)
+    })
+    view.unmount()
+    await waitFor(() => {
+      expect(querySubscriptions.ownerMeta.size).toBe(0)
+      expect(querySubscriptions.queries.size).toBe(0)
+    })
+  })
+})
+
+function createQueryComponent (marker) {
+  return observer(function QueryComponent ({ renderId }) {
+    useBatchSub($testRoot[`useSubLease_${marker}`], { marker }, { defer: false })
+    useBatchSub()
+    return el('span', {}, `render-${renderId}`)
+  })
+}
+
+function SharedQueries ({ QueryComponent, second }) {
+  return el(
+    'div',
+    {},
+    el(QueryComponent, { key: 'first', renderId: 1 }),
+    second ? el(QueryComponent, { key: 'second', renderId: 2 }) : null
+  )
+}
+
+const BatchedAggregationPage = observer(function BatchedAggregationPage ({ mountId }) {
+  useBatchSub($testRoot.useSubLeaseAggregations, {
+    $aggregate: [{ $match: { marker: `list-${mountId}` } }]
+  }, { defer: false })
+  useBatchSub($testRoot.useSubLeaseAggregations, {
+    $aggregate: [{ $match: { marker: `count-${mountId}` } }]
+  }, { defer: false })
+  useBatchSub()
+  return el('span', {}, `page-${mountId}`)
+})
+
+async function waitForContent (container, content) {
+  await waitFor(() => expect(container.textContent).toBe(content))
+}
+
+async function waitForLeaseCleanup () {
+  await wait(50)
+}
+
+async function wait (ms) {
+  await act(async () => {
+    await new Promise(resolve => setTimeout(resolve, ms))
+  })
+}
+
+function sum (values) {
+  let total = 0
+  for (const value of values) total += value || 0
+  return total
+}

--- a/packages/teamplay/test_client/40_use-sub-lifecycle.js
+++ b/packages/teamplay/test_client/40_use-sub-lifecycle.js
@@ -131,6 +131,42 @@ describe('useSub subscription ownership', () => {
       expect(querySubscriptions.queries.size).toBe(0)
     })
   })
+
+  it('keeps ready batch ownership while a sibling subscription is pending', async () => {
+    const subscription = pauseQuerySubscription('slow-batch')
+    try {
+      const view = render(el(StaggeredBatchPage))
+      await waitForContent(view.container, 'Loading')
+      await wait(100)
+
+      expect(getQueryOwnerCount('slow-batch')).toBe(1)
+      expect(getQueryOwnerCount('fast-batch')).toBe(1)
+
+      await subscription.resume()
+      await waitForContent(view.container, 'Ready')
+    } finally {
+      await subscription.resume()
+      subscription.restore()
+      await waitForLeaseCleanup()
+    }
+  })
+
+  it('releases pending query ownership when a suspended page unmounts', async () => {
+    const subscription = pauseQuerySubscription('pending-unmount')
+    try {
+      const view = render(el(PendingSubscriptionPage))
+      await waitFor(() => expect(getQueryOwnerCount('pending-unmount')).toBe(1))
+
+      view.unmount()
+      await wait(100)
+
+      expect(getQueryOwnerCount('pending-unmount')).toBe(0)
+    } finally {
+      await subscription.resume()
+      subscription.restore()
+      await waitForLeaseCleanup()
+    }
+  })
 })
 
 function createQueryComponent (marker) {
@@ -160,6 +196,59 @@ const BatchedAggregationPage = observer(function BatchedAggregationPage ({ mount
   useBatchSub()
   return el('span', {}, `page-${mountId}`)
 })
+
+const StaggeredBatchPage = observer(function StaggeredBatchPage () {
+  useBatchSub($testRoot.useSubLeaseStaggered, { marker: 'fast-batch' }, { defer: false })
+  useBatchSub($testRoot.useSubLeaseStaggered, { marker: 'slow-batch' }, { defer: false })
+  useBatchSub()
+  return el('span', {}, 'Ready')
+}, { suspenseProps: { fallback: el('span', {}, 'Loading') } })
+
+const PendingSubscriptionPage = observer(function PendingSubscriptionPage () {
+  useBatchSub($testRoot.useSubLeasePending, { marker: 'pending-unmount' }, { defer: false })
+  useBatchSub()
+  return el('span', {}, 'Ready')
+})
+
+function pauseQuerySubscription (marker) {
+  const queryProto = querySubscriptions.QueryClass.prototype
+  const originalSubscribe = queryProto._subscribe
+  let pendingPromise
+  let resume
+
+  queryProto._subscribe = function (...args) {
+    if (this.params?.marker !== marker) return originalSubscribe.apply(this, args)
+    if (pendingPromise) return pendingPromise
+
+    let resumed = false
+    pendingPromise = new Promise((resolve, reject) => {
+      resume = () => {
+        if (resumed) return
+        resumed = true
+        Promise.resolve(originalSubscribe.apply(this, args)).then(resolve, reject)
+      }
+    })
+    return pendingPromise
+  }
+
+  return {
+    async resume () {
+      resume?.()
+      await pendingPromise
+    },
+    restore () {
+      queryProto._subscribe = originalSubscribe
+    }
+  }
+}
+
+function getQueryOwnerCount (marker) {
+  for (const ownerKey of querySubscriptions.ownerMeta.keys()) {
+    if (querySubscriptions.ownerMeta.get(ownerKey)?.params?.marker !== marker) continue
+    return querySubscriptions.ownerSubscribeCount.get(ownerKey) || 0
+  }
+  return 0
+}
 
 async function waitForContent (container, content) {
   await waitFor(() => expect(container.textContent).toBe(content))


### PR DESCRIPTION
## Summary

- keep one component-owned useSub() lease for stable signal and query arguments across ordinary rerenders and Suspense retries
- expose the acquired signal to React leases while transport setup is pending, so a suspended page can release ownership on unmount
- keep ready batched leases alive until the complete batch barrier settles instead of timing each query independently
- preserve the previous snapshot through replacement readiness and protect React StrictMode subscription replay
- cover repeated rerenders and unmounts, shared queries, batched aggregations, staggered batch readiness, pending transport unmounts, StrictMode, and abandoned Suspense work

## Why

useSub() previously called sub() on every render without a matching component lifecycle release. Repeated renders and page mount/unmount cycles incremented subscription ownership until signal GC, allowing live query ownership to accumulate.

The follow-up review found two additional lifecycle gaps: a fast batch member could lose ownership while a slower sibling still held the barrier, and a transport promise that had not settled could not be released when its suspended page unmounted. This PR now owns pending acquisitions from the outer observer cache and schedules batch cleanup from the complete render barrier.

## TDD

- RED: staggered fast/slow batch reproduced the fast owner dropping to zero while the page was still suspended
- RED: pending transport unmount reproduced the owner remaining at one after the page was removed
- GREEN: both regressions pass alongside the original six lifecycle cases

## Validation

- npm test (30 Babel tests, 444 server tests passing with 4 pending, 119 client tests passing)
- npm run lint
- npm run build