### PR TITLE
Fix query readiness across Suspense retries

### DIFF
--- a/packages/teamplay/src/react/useSub.ts
+++ b/packages/teamplay/src/react/useSub.ts
@@ -491,7 +491,7 @@ export function useSubDeferred (
   // 1. if it's a promise, throw it so that Suspense can catch it and wait for subscription to finish
   if (isThenable(promiseOrSignal)) {
     const promise = maybeThrottle(promiseOrSignal)
-    const readyPromise = batch ? getBatchReadyPromise(promise) : promise
+    const readyPromise = getSubscriptionReadyPromise(promise, subscriptionLease)
     scheduleRenderAttemptLeaseCleanup(subscriptionLease, readyPromise, batch)
     const hasPreviousSignal = !!$signalRef.current
     if (batch) {
@@ -499,7 +499,7 @@ export function useSubDeferred (
       // On resubscribe we keep rendering previous signal and refresh in background.
       if (!hasPreviousSignal) {
         promiseBatcher.add(promise)
-        addBatchReadinessCheck(promise)
+        addBatchReadinessCheck(promise, subscriptionLease)
       } else {
         scheduleUpdate(readyPromise)
       }
@@ -507,21 +507,20 @@ export function useSubDeferred (
       return $signalRef.current
     }
     if (async) {
-      scheduleUpdate(promise)
+      scheduleUpdate(readyPromise)
       return
     }
     // Keep previous snapshot during update re-subscribe and refresh in background.
     if (hasPreviousSignal) {
-      scheduleUpdate(promise)
+      scheduleUpdate(readyPromise)
       return $signalRef.current
     }
-    scheduleGroupUpdate?.(promise)
-    throw promise
+    scheduleGroupUpdate?.(readyPromise)
+    throw readyPromise
   // 2. if it's a signal, we save it into ref to make sure it's not garbage collected while component exists
   } else {
     const $signal = promiseOrSignal
-    scheduleRenderAttemptLeaseCleanup(subscriptionLease, Promise.resolve(), batch)
-    if (batch && !$signalRef.current) addBatchReadinessCheckForSignal($signal)
+    if (batch && !$signalRef.current) addBatchReadinessCheckForSignal($signal, subscriptionLease)
     if ($signalRef.current !== $signal) $signalRef.current = $signal
     return $signal
   }
@@ -544,7 +543,7 @@ export function useSubClassic (
   // 1. if it's a promise, throw it so that Suspense can catch it and wait for subscription to finish
   if (isThenable(promiseOrSignal)) {
     const promise = maybeThrottle(promiseOrSignal)
-    const readyPromise = batch ? getBatchReadyPromise(promise) : promise
+    const readyPromise = getSubscriptionReadyPromise(promise, subscriptionLease)
     scheduleRenderAttemptLeaseCleanup(subscriptionLease, readyPromise, batch)
     if (batch) {
       const hasPreviousSignal = cache.has(id)
@@ -552,7 +551,7 @@ export function useSubClassic (
       // On resubscribe we keep rendering previous signal and refresh in background.
       if (!hasPreviousSignal) {
         promiseBatcher.add(promise)
-        addBatchReadinessCheck(promise)
+        addBatchReadinessCheck(promise, subscriptionLease)
       } else {
         scheduleUpdate(readyPromise)
       }
@@ -567,23 +566,22 @@ export function useSubClassic (
       // We manually schedule an update when promise resolves since we can't
       // rely on Suspense in this case to automatically trigger component's re-render
       if (async) {
-        scheduleUpdate(promise)
+        scheduleUpdate(readyPromise)
         return
       }
       // in regular mode we throw the promise to be caught by Suspense
       // this way we guarantee that the signal with all the data
       // will always be there when component is rendered
-      scheduleGroupUpdate?.(promise)
-      throw promise
+      scheduleGroupUpdate?.(readyPromise)
+      throw readyPromise
     }
     // if we already have a previous signal, we return it and wait for new promise to resolve
-    scheduleUpdate(promise)
+    scheduleUpdate(readyPromise)
     return cache.get(id)
   // 2. if it's a signal, we save it into ref to make sure it's not garbage collected while component exists
   } else {
     const $signal = promiseOrSignal
-    scheduleRenderAttemptLeaseCleanup(subscriptionLease, Promise.resolve(), batch)
-    if (batch && !cache.has(id)) addBatchReadinessCheckForSignal($signal)
+    if (batch && !cache.has(id)) addBatchReadinessCheckForSignal($signal, subscriptionLease)
     if (cache.get(id) !== $signal) {
       cache.set(id, $signal)
     }
@@ -636,6 +634,9 @@ function useSubscriptionLease (signal: unknown, params?: unknown): SubscriptionL
     nextLease.unregisterCacheDestroy = cache.onDestroy(() => releaseSubscriptionLease(nextLease))
     lease = nextLease
     cache.set(cacheKey, nextLease)
+  } else {
+    clearTimeout(lease.cleanupTimer)
+    lease.cleanupTimer = undefined
   }
 
   useEffect(() => {
@@ -774,7 +775,10 @@ function maybeThrottle<TValue> (promise: Promise<TValue>): Promise<TValue> {
   })
 }
 
-function addBatchReadinessCheck (promise: PromiseLike<unknown>): void {
+function addBatchReadinessCheck (
+  promise: PromiseLike<unknown>,
+  lease?: SubscriptionLease
+): void {
   let resolvedSignal: unknown
   let resolved = false
   promise.then(signal => {
@@ -786,41 +790,50 @@ function addBatchReadinessCheck (promise: PromiseLike<unknown>): void {
   promiseBatcher.addCheck({
     key: promise,
     type: 'subscription',
-    isReady: () => resolved && isBatchSignalReady(resolvedSignal),
+    isReady: () => !!lease?.released || (resolved && isSubscriptionSignalReady(resolvedSignal)),
     getState: () => getBatchSignalState(resolvedSignal)
   })
 }
 
-function getBatchReadyPromise (promise: PromiseLike<unknown>): Promise<unknown> {
+function getSubscriptionReadyPromise (
+  promise: PromiseLike<unknown>,
+  lease?: SubscriptionLease
+): Promise<unknown> {
   return Promise.resolve(promise).then(async signal => {
-    await waitForBatchSignalReady(signal)
+    await waitForSubscriptionSignalReady(signal, lease)
     return signal
   })
 }
 
-async function waitForBatchSignalReady (signal: unknown): Promise<void> {
-  while (!isBatchSignalReady(signal)) {
+async function waitForSubscriptionSignalReady (
+  signal: unknown,
+  lease?: SubscriptionLease
+): Promise<void> {
+  while (!lease?.released && !isSubscriptionSignalReady(signal)) {
     await new Promise(resolve => setTimeout(resolve, 16))
   }
 }
 
-function addBatchReadinessCheckForSignal (signal: unknown): void {
-  if (isBatchSignalReady(signal)) return
+function addBatchReadinessCheckForSignal (
+  signal: unknown,
+  lease?: SubscriptionLease
+): void {
+  if (isSubscriptionSignalReady(signal)) return
   const promise = Promise.resolve(signal)
   promiseBatcher.add(promise)
-  addBatchReadinessCheck(promise)
+  addBatchReadinessCheck(promise, lease)
 }
 
-function isBatchSignalReady (signal: unknown): boolean {
+function isSubscriptionSignalReady (signal: unknown): boolean {
   if (isPublicDocumentSignal(signal)) {
     const $doc = signal as SignalBaseInstance
     return isDocReady($doc[SEGMENTS])
   }
-  if (isQuerySignal(signal)) return isBatchQueryReady(signal)
+  if (isQuerySignal(signal)) return isSubscriptionQueryReady(signal)
   return true
 }
 
-function isBatchQueryReady (signal: BatchQuerySignal): boolean {
+function isSubscriptionQueryReady (signal: BatchQuerySignal): boolean {
   const collection = signal[COLLECTION_NAME]
   const params = signal[PARAMS]
   if (!isBatchQueryTransportStable(signal)) return false

--- a/packages/teamplay/test_client/40_use-sub-lifecycle.js
+++ b/packages/teamplay/test_client/40_use-sub-lifecycle.js
@@ -1,7 +1,7 @@
 import { createElement as el, StrictMode, Suspense } from 'react'
 import { afterEach, beforeAll, beforeEach, describe, expect, it } from '@jest/globals'
 import { act, cleanup, render, waitFor } from '@testing-library/react'
-import { getRootSignal, observer, useBatchSub } from '../src/index.ts'
+import { getRootSignal, observer, useBatchSub, useSub } from '../src/index.ts'
 import { querySubscriptions } from '../src/orm/Query.js'
 import { aggregationSubscriptions } from '../src/orm/Aggregation.js'
 import {
@@ -167,7 +167,73 @@ describe('useSub subscription ownership', () => {
       await waitForLeaseCleanup()
     }
   })
+
+  it('keeps earlier query data through a chain of suspended subscriptions', async () => {
+    setTestThrottling(80)
+    const renderStates = []
+
+    const Component = observer(function ChainedSubscriptionsPage () {
+      const $firstQuery = useChainedQuery(0)
+      useChainedQuery(1)
+      useChainedQuery(2)
+      useChainedQuery(3)
+      useChainedQuery(4)
+      useChainedQuery(5)
+      const state = Array.isArray($firstQuery.get()) ? 'Ready' : 'Premature'
+      renderStates.push(state)
+      return el('span', {}, state)
+    }, { suspenseProps: { fallback: el('span', {}, 'Loading') } })
+
+    const view = render(el(Component))
+    for (let index = 0; index < 7; index++) await wait(100)
+
+    expect(renderStates).not.toContain('Premature')
+    expect(view.container.textContent).toBe('Ready')
+  })
+
+  it.each([
+    ['useSub', false],
+    ['useBatchSub', true]
+  ])('keeps %s suspended until query data is materialized', async (_name, batch) => {
+    const collection = `useSubMaterialization_${batch ? 'batch' : 'plain'}`
+    const marker = `materialization-${batch ? 'batch' : 'plain'}`
+    const materialization = delayQueryMaterialization(collection, marker)
+
+    try {
+      const PlainComponent = observer(function PlainMaterializationPage () {
+        const $query = useSub($testRoot[collection], { marker }, { defer: false })
+        const docs = $query.get()
+        return el('span', {}, Array.isArray(docs) ? 'Ready' : 'Premature')
+      }, { suspenseProps: { fallback: el('span', {}, 'Loading') } })
+      const BatchComponent = observer(function BatchMaterializationPage () {
+        const $query = useBatchSub($testRoot[collection], { marker }, { defer: false })
+        useBatchSub()
+        const docs = $query.get()
+        return el('span', {}, Array.isArray(docs) ? 'Ready' : 'Premature')
+      }, { suspenseProps: { fallback: el('span', {}, 'Loading') } })
+      const Component = batch ? BatchComponent : PlainComponent
+
+      const view = render(el(Component))
+      await waitForContent(view.container, 'Loading')
+      await wait(20)
+      expect(view.container.textContent).toBe('Loading')
+
+      await materialization.resume()
+      await waitForContent(view.container, 'Ready')
+    } finally {
+      await materialization.resume()
+      materialization.restore()
+    }
+  })
 })
+
+function useChainedQuery (index) {
+  return useSub(
+    $testRoot.useSubLeaseChainedAttempts,
+    { marker: `chained-subscription-${index}` },
+    { defer: false }
+  )
+}
 
 function createQueryComponent (marker) {
   return observer(function QueryComponent ({ renderId }) {
@@ -238,6 +304,37 @@ function pauseQuerySubscription (marker) {
     },
     restore () {
       queryProto._subscribe = originalSubscribe
+    }
+  }
+}
+
+function delayQueryMaterialization (collection, marker) {
+  const queryProto = querySubscriptions.QueryClass.prototype
+  const originalSyncRootData = queryProto._syncRootData
+  let pendingPromise
+  let resume
+
+  queryProto._syncRootData = function (...args) {
+    if (this.collectionName !== collection || this.params?.marker !== marker) {
+      return originalSyncRootData.apply(this, args)
+    }
+    if (!pendingPromise) {
+      pendingPromise = new Promise(resolve => {
+        resume = () => {
+          originalSyncRootData.apply(this, args)
+          resolve()
+        }
+      })
+    }
+  }
+
+  return {
+    async resume () {
+      resume?.()
+      await pendingPromise
+    },
+    restore () {
+      queryProto._syncRootData = originalSyncRootData
     }
   }
 }


### PR DESCRIPTION
## Summary

- keep a reused uncommitted React subscription lease alive across sequential Suspense render attempts
- resolve plain and batched `useSub` promises only after the subscribed signal/query is materially readable
- stop readiness polling when its lease is released, preserving cleanup for genuinely abandoned renders

## Root cause

TeamPlay 0.5.4 introduced cleanup for React subscription leases. A lease reused by a later Suspense retry could still retain the cleanup timer created by an earlier render attempt. In a component with several sequential `useSub` calls, that timer could release an earlier query before the component committed, leaving consumers with an unmaterialized query signal.

There was also an older latent contract gap: the transport subscription promise can settle before the root query data is visible in the signal. Both plain and batched paths now share an explicit materialization-readiness gate.

The first bad release for the lease regression is **v0.5.4**; **v0.5.3** is good. The introducing commit is `ad8fdf52d7f674471ff3114bb8b79d2487960316` (`fix(teamplay): release React subscription leases`).

## TDD coverage

- regression test with six sequential plain `useSub` calls under Suspense
  - stays on `Loading` on unmodified v0.5.4
  - reaches `Ready` with this fix
- plain `useSub` remains suspended until delayed query-root materialization
- `useBatchSub` remains suspended until delayed query-root materialization
- existing uncommitted-render cleanup and resubscribe/cache lifecycle tests remain green, guarding against reaction and signal leaks

## Validation

- client suite: **122/122 passing**
- server suite: **444 passing, 4 pending**
- `yarn test-types`
- `yarn test-types:external`
- `yarn lint`
- `yarn build`
- `git diff --check`

## LMS smoke with the locally packed build

- `/admin/users` renders
- `/p/v5/my-courses/published` renders
- professor course page renders
- `/p/v5/profile` renders

Two observed local issues are unrelated to this TeamPlay change:

- a tested stage-play URL returns 404 because that stage document is absent from the local dev database
- profile logs a pre-existing Google Calendar `client_id` environment/configuration error
