### PR TITLE
Fix useNow stability across SuspenseGroup retries

### DIFF
--- a/packages/teamplay/src/react/wrapIntoSuspense.js
+++ b/packages/teamplay/src/react/wrapIntoSuspense.js
@@ -24,13 +24,13 @@ export function SuspenseGroup ({ children, fallback = null }) {
 
   return el(
     SuspenseGroupContext.Provider,
-    { value: store.scheduleUpdate },
+    { value: store },
     el(Suspense, { fallback }, children)
   )
 }
 
 export function useSuspenseGroupScheduleUpdate () {
-  return useContext(SuspenseGroupContext)
+  return useContext(SuspenseGroupContext)?.scheduleUpdate
 }
 
 function createSuspenseGroupStore () {
@@ -39,6 +39,7 @@ function createSuspenseGroupStore () {
   const scheduled = new WeakSet()
 
   return {
+    createdAt: Date.now(),
     subscribe (listener) {
       listeners.add(listener)
       return () => listeners.delete(listener)
@@ -90,7 +91,8 @@ export default function wrapIntoSuspense ({
   if (!suspenseProps?.fallback) throw Error(ERRORS.noFallback)
 
   let SuspenseWrapper = (props, ref) => {
-    const inheritsSuspense = !!useContext(SuspenseGroupContext)
+    const suspenseGroup = useContext(SuspenseGroupContext)
+    const inheritsSuspense = !!suspenseGroup
     const componentId = useId()
     const componentMetaRef = useRef()
     const admRef = useRef()
@@ -141,7 +143,7 @@ export default function wrapIntoSuspense ({
     if (!componentMetaRef.current) {
       componentMetaRef.current = {
         componentId,
-        createdAt: Date.now(),
+        createdAt: suspenseGroup?.createdAt ?? Date.now(),
         defer,
         triggerUpdate: () => {
           if (adm.onStoreChange) {

--- a/packages/teamplay/test_client/35_suspense-group.js
+++ b/packages/teamplay/test_client/35_suspense-group.js
@@ -6,6 +6,7 @@ import {
   observer,
   SuspenseGroup,
   useBatchSub,
+  useNow,
   useSub,
   useSuspendMemo,
   useSuspenseGroupScheduleUpdate
@@ -32,6 +33,28 @@ describe('SuspenseGroup', () => {
 
     expect(container.querySelector('[data-testid="outer-fallback"]')).toBeFalsy()
     expect(container.textContent).toBe('')
+  })
+
+  it('keeps a query keyed by useNow stable outside a group', async () => {
+    const timestamps = new Set()
+
+    const Child = observer(() => {
+      const now = useNow()
+      timestamps.add(now)
+      if (timestamps.size > 1) {
+        throw Error('useNow changed before the observer subscription committed')
+      }
+      useBatchSub($.observerStableNow, { marker: now }, { defer: false })
+      useBatchSub()
+      return el('div', { 'data-testid': 'observer-query-content' }, 'Ready')
+    })
+
+    const { container } = render(el(Child))
+
+    await waitFor(() => {
+      expect(container.querySelector('[data-testid="observer-query-content"]')).toBeTruthy()
+    })
+    expect(timestamps.size).toBe(1)
   })
 
   it('retries suspended children when a registered promise settles', async () => {
@@ -105,6 +128,63 @@ describe('SuspenseGroup', () => {
       expect(container.querySelector('[data-testid="batch-content"]')).toBeTruthy()
     })
     expect(container.querySelector('[data-testid="group-fallback"]')).toBeFalsy()
+  })
+
+  it('keeps useNow stable across uncommitted group retries', async () => {
+    const wake = deferred()
+    const timestamps = new Set()
+    let ready = false
+
+    const Child = observer(() => {
+      timestamps.add(useNow())
+      const scheduleUpdate = useSuspenseGroupScheduleUpdate()
+      scheduleUpdate(wake.promise)
+      if (!ready) throw wake.promise
+      return el('div', { 'data-testid': 'stable-now-content' }, 'Ready')
+    })
+
+    const { container } = render(
+      el(SuspenseGroup, {
+        fallback: el('div', { 'data-testid': 'group-fallback' }, 'Loading')
+      }, el(Child))
+    )
+
+    await act(async () => {
+      ready = true
+      wake.resolve()
+      await wake.promise
+    })
+
+    await waitFor(() => {
+      expect(container.querySelector('[data-testid="stable-now-content"]')).toBeTruthy()
+    })
+    expect(timestamps.size).toBe(1)
+  })
+
+  it('keeps a query keyed by useNow stable while the group is suspended', async () => {
+    const timestamps = new Set()
+
+    const Child = observer(() => {
+      const now = useNow()
+      timestamps.add(now)
+      if (timestamps.size > 1) {
+        throw Error('useNow changed before the grouped subscription committed')
+      }
+      useBatchSub($.suspenseGroupStableNow, { marker: now }, { defer: false })
+      useBatchSub()
+      return el('div', { 'data-testid': 'stable-query-content' }, 'Ready')
+    })
+
+    const { container } = render(
+      el(SuspenseGroup, {
+        fallback: el('div', { 'data-testid': 'group-fallback' }, 'Loading')
+      }, el(Child))
+    )
+
+    await waitFor(() => {
+      expect(container.querySelector('[data-testid="stable-query-content"]')).toBeTruthy()
+    })
+    expect(timestamps.size).toBe(1)
   })
 
   it('groups useSuspendMemo under the shared fallback', async () => {

--- a/packages/teamplay/test_client/40_use-sub-lifecycle.js
+++ b/packages/teamplay/test_client/40_use-sub-lifecycle.js
@@ -185,7 +185,7 @@ describe('useSub subscription ownership', () => {
     }, { suspenseProps: { fallback: el('span', {}, 'Loading') } })
 
     const view = render(el(Component))
-    for (let index = 0; index < 7; index++) await wait(100)
+    await waitForContent(view.container, 'Ready', { timeout: 5000 })
 
     expect(renderStates).not.toContain('Premature')
     expect(view.container.textContent).toBe('Ready')
@@ -347,8 +347,8 @@ function getQueryOwnerCount (marker) {
   return 0
 }
 
-async function waitForContent (container, content) {
-  await waitFor(() => expect(container.textContent).toBe(content))
+async function waitForContent (container, content, options) {
+  await waitFor(() => expect(container.textContent).toBe(content), options)
 }
 
 async function waitForLeaseCleanup () {


### PR DESCRIPTION
## Summary

- keep `useNow()` stable across uncommitted retries inside one `SuspenseGroup`
- preserve the existing `useSuspenseGroupScheduleUpdate()` API
- leave standalone `observer()` behavior unchanged
- add query-level regression coverage for grouped and non-grouped rendering
- make the existing chained-subscription regression wait for actual readiness instead of a fixed 700 ms sleep

## Root cause

`SuspenseGroup` owns the retry boundary, so suspended child observer wrappers can be recreated before they ever commit. Each recreation previously received a new component `createdAt`. Queries keyed by `useNow()` therefore changed identity on every retry: the prior render never committed its cleanup while the next render subscribed to a new query.

The group store already survives these retries. It now owns the stable `createdAt` used by observer children for that group's initial materialization.

## TDD evidence

Before the fix, the regression test failed because one grouped render observed two timestamps; the query integration guard failed with `useNow changed before the grouped subscription committed`.

After the fix:

- `yarn lint`
- `yarn test`: 30 Babel plugin tests, 444 server tests passed (4 existing pending), 125 client tests passed
- `yarn test-types:dist`
- pre-commit full test suite
- GitHub Actions `test` passed

The first usable CI run also exposed a pre-existing wall-clock wait in the chained-subscription test on the slower Linux runner. The assertion still verifies eventual `Ready` and forbids `Premature`, but now waits for the state condition with a bounded timeout.

## LMS runtime verification

Using a packed build of this branch:

- `/s/v5/my-courses`: 11 startup query subscriptions, 0 settled subscription actions
- student course route: 24 startup query subscriptions, 0 settled subscription actions
- professor course list and course page: rendered without query churn
- `/admin/users`: 13 startup query subscriptions, 0 settled subscription actions
- behavior without `SuspenseGroup` is covered by a dedicated regression test
