### PR TITLE
fix(teamplay): stabilize SuspenseGroup observer retries

### DIFF
--- a/docs/guide/react-integration.md
+++ b/docs/guide/react-integration.md
@@ -118,12 +118,15 @@ function PlayerRoute ({ children }) {
 
 Inside the group, default Suspense boundaries added by `observer()` are
 consolidated into the group boundary. TeamPlay automatically schedules retries
-for initial `useSub()`, `useBatchSub()`, and `useSuspendMemo()` promises. An
-observer with an explicit `suspenseProps.fallback` keeps its own boundary.
+for initial `useSub()`, `useBatchSub()`, and `useSuspendMemo()` promises, as well
+as any other thenable thrown directly while rendering an `observer()` component.
+An observer with an explicit `suspenseProps.fallback` keeps its own boundary.
 Outside `SuspenseGroup`, observer behavior is unchanged.
 
-For a stable promise that TeamPlay does not create, such as a memoized
-`React.lazy()` loader, register it explicitly:
+TeamPlay cannot intercept a promise thrown later by an arbitrary non-observer
+descendant because React evaluates that descendant in a separate fiber. For a
+stable promise owned by such a descendant, such as a memoized `React.lazy()`
+loader, register it explicitly:
 
 ```javascript
 import React from 'react'

--- a/packages/teamplay/src/react/convertToObserver.js
+++ b/packages/teamplay/src/react/convertToObserver.js
@@ -6,6 +6,7 @@ import { __increment, __decrement } from '@teamplay/debug'
 import executionContextTracker from './executionContextTracker.ts'
 import { pipeComponentMeta, useUnmount, useId, useTriggerUpdate } from './helpers.ts'
 import trapRender from './trapRender.js'
+import { useSuspenseGroupScheduleUpdate } from './wrapIntoSuspense.js'
 import { scheduleReaction } from '../orm/batchScheduler.js'
 
 const DEFAULT_THROTTLE_TIMEOUT = 100
@@ -27,6 +28,7 @@ export default function convertToObserver (BaseComponent, {
     const [cache, destroyCache] = useCreateCacheRef(enableCache)
     const componentId = useId()
     const triggerUpdate = useTriggerUpdate()
+    const scheduleGroupUpdate = useSuspenseGroupScheduleUpdate()
 
     // wrap the BaseComponent into an observe decorator once.
     // This way it will track any observable changes and will trigger rerender
@@ -63,7 +65,8 @@ export default function convertToObserver (BaseComponent, {
         render: BaseComponent,
         cache,
         destroy: destroyRef.current,
-        componentId
+        componentId,
+        scheduleGroupUpdate
       })
       reactionRef.current = observe(trappedRender, {
         scheduler: () => scheduleReaction(update),

--- a/packages/teamplay/src/react/trapRender.js
+++ b/packages/teamplay/src/react/trapRender.js
@@ -4,7 +4,13 @@ import executionContextTracker from './executionContextTracker.ts'
 import * as promiseBatcher from './promiseBatcher.ts'
 import renderAttemptDestroyer from './renderAttemptDestroyer.ts'
 
-export default function trapRender ({ render, cache, destroy, componentId }) {
+export default function trapRender ({
+  render,
+  cache,
+  destroy,
+  componentId,
+  scheduleGroupUpdate
+}) {
   return (...args) => {
     executionContextTracker._start(componentId)
     cache.activate()
@@ -24,6 +30,7 @@ export default function trapRender ({ render, cache, destroy, componentId }) {
         destroyed = true
         throw err
       }
+      scheduleGroupUpdate?.(err)
       const {
         shouldKeepShellAlive
       } = renderAttemptDestroyer.consumeThenableHandling()

--- a/packages/teamplay/test_client/35_suspense-group.js
+++ b/packages/teamplay/test_client/35_suspense-group.js
@@ -19,6 +19,40 @@ afterEach(cleanup)
 afterEach(runGc)
 
 describe('SuspenseGroup', () => {
+  it('registers any observer thenable with the group retry coordinator', async () => {
+    const retries = []
+    const thenable = {
+      then (onFulfilled) {
+        retries.push(onFulfilled)
+      }
+    }
+    let ready = false
+
+    const Child = observer(() => {
+      if (!ready) throw thenable
+      return el('div', { 'data-testid': 'arbitrary-content' }, 'Ready')
+    })
+
+    const { container } = render(
+      el(SuspenseGroup, {
+        fallback: el('div', { 'data-testid': 'group-fallback' }, 'Loading')
+      }, el(Child))
+    )
+
+    expect(container.querySelector('[data-testid="group-fallback"]')).toBeTruthy()
+    expect(retries.length).toBeGreaterThanOrEqual(2)
+
+    await act(async () => {
+      ready = true
+      retries[0]()
+      await Promise.resolve()
+    })
+
+    await waitFor(() => {
+      expect(container.querySelector('[data-testid="arbitrary-content"]')).toBeTruthy()
+    })
+  })
+
   it('keeps the default observer boundary unchanged outside a group', () => {
     const blocker = new Promise(() => {})
     const Child = observer(() => {


### PR DESCRIPTION
## Summary

- register every thenable thrown directly from an `observer()` render with the enclosing `SuspenseGroup` retry coordinator
- preserve observer behavior outside a group and explicit per-observer fallbacks
- document the non-observer descendant boundary and explicit registration pattern
- add an integration regression test that exercises the real `observer()` -> group coordinator path

## Root cause

`SuspenseGroup` already coordinated promises created by `useSub`, `useBatchSub`, and `useSuspendMemo`, but an arbitrary thenable thrown directly from an observer render could rely only on React's retry. Under scheduler pressure this could leave the shared fallback visible until an unrelated high-priority update occurred.

The observer wrapper now hands such thenables to the existing group store before rethrowing them to React. No polling, timers, or fallback-specific retry loop is introduced.

Promises thrown later by arbitrary non-observer descendant fibers cannot be intercepted by the observer wrapper; the guide now documents explicit registration for stable resources owned by those descendants.

## TDD

The new integration test deliberately invokes only the group-coordinator retry callback:

- before the runtime change: RED, content remains on the group fallback
- after the runtime change: GREEN, content commits

## Validation

- `yarn lint`
- `yarn test`: 30 plugin tests, 444 server tests passing (4 pending), 126 client tests passing
- `yarn build`
- local LMS integration: authenticated player profile, course, and stage routes completed without resize/tab-switch triggers
