### PR TITLE
fix(teamplay): prevent pending lease double unsubscribe

### DIFF
--- a/packages/teamplay/src/react/useSub.ts
+++ b/packages/teamplay/src/react/useSub.ts
@@ -608,6 +608,7 @@ export function setDefaultDefer (value: boolean): void {
 interface SubscriptionLease {
   value: unknown
   signal?: unknown
+  signalDisposed: boolean
   inputSignal?: unknown
   serializedParams?: string
   previousLease?: SubscriptionLease
@@ -674,7 +675,8 @@ function createSubscriptionLease (
     serializedParams,
     previousLease: previousLease?.released ? undefined : previousLease,
     committed: false,
-    released: false
+    released: false,
+    signalDisposed: false
   }
 
   if (isThenable(value)) {
@@ -758,7 +760,11 @@ function disposeSubscriptionLeaseSignal (lease: SubscriptionLease): void {
   lease.inputSignal = undefined
   lease.serializedParams = undefined
   lease.value = undefined
-  if (!signal) return
+  // A pending sub result exposes its signal before its promise settles. If this
+  // lease was released while pending, the resolution callback sees the same
+  // acquisition again and must not unsubscribe another owner's matching record.
+  if (!signal || lease.signalDisposed) return
+  lease.signalDisposed = true
   Promise.resolve(unsub(signal)).catch(ignoreSubscriptionCleanupError)
 }
 

--- a/packages/teamplay/test_client/40_use-sub-lifecycle.js
+++ b/packages/teamplay/test_client/40_use-sub-lifecycle.js
@@ -168,6 +168,40 @@ describe('useSub subscription ownership', () => {
     }
   })
 
+  it('does not let a released pending lease unsubscribe a later owner when it resolves', async () => {
+    const marker = 'pending-owner-handoff'
+    const subscription = pauseQuerySubscription(marker)
+    const Component = createPlainQueryComponent(marker)
+    let firstView
+    let secondView
+
+    try {
+      firstView = render(el(Component))
+      await waitFor(() => expect(getQueryOwnerCount(marker)).toBe(1))
+
+      secondView = render(el(Component))
+      await waitFor(() => expect(getQueryOwnerCount(marker)).toBe(2))
+
+      firstView.unmount()
+      await waitFor(() => expect(getQueryOwnerCount(marker)).toBe(1))
+
+      await act(async () => {
+        await subscription.resume()
+      })
+      await waitForLeaseCleanup()
+
+      expect(getQueryOwnerCount(marker)).toBe(1)
+      await waitForContent(secondView.container, 'Ready')
+      expect(secondView.container.textContent).toBe('Ready')
+    } finally {
+      firstView?.unmount()
+      secondView?.unmount()
+      await subscription.resume()
+      subscription.restore()
+      await waitForLeaseCleanup()
+    }
+  })
+
   it('keeps earlier query data through a chain of suspended subscriptions', async () => {
     setTestThrottling(80)
     const renderStates = []
@@ -241,6 +275,17 @@ function createQueryComponent (marker) {
     useBatchSub()
     return el('span', {}, `render-${renderId}`)
   })
+}
+
+function createPlainQueryComponent (marker) {
+  return observer(function PlainQueryComponent () {
+    const $query = useSub(
+      $testRoot[`useSubLease_${marker}`],
+      { marker },
+      { defer: false }
+    )
+    return el('span', {}, Array.isArray($query.get()) ? 'Ready' : 'Premature')
+  }, { suspenseProps: { fallback: el('span', {}, 'Loading') } })
 }
 
 function SharedQueries ({ QueryComponent, second }) {


### PR DESCRIPTION
## Summary

- make React subscription lease disposal idempotent for its single acquisition
- prevent a resolved abandoned lease from consuming a later owner's subscription record
- add a deterministic Suspense ownership-handoff regression test

## Root cause

`getSubResultSignal()` exposes the query signal while its transport promise is still pending so an abandoned render can release ownership promptly. The pending promise later resolves with that same signal.

When the abandoned lease had already been released, its resolution callback restored the signal and called `disposeSubscriptionLeaseSignal()` again. That second `unsub()` removed the remaining live owner's record, dropped query ownership to zero, and detached freshly materialized query data. A retry could then receive a synchronous query signal whose `.get()` returned `undefined`.

The fix records whether the lease has already disposed its one subscription acquisition and makes repeated disposal a no-op. It stores only a boolean and does not retain the signal.

## TDD

The regression test creates two pending owners for one query, unmounts the first owner, and then resolves the shared transport.

- RED on v0.5.7: expected the surviving owner count to be `1`, received `0`
- GREEN with this change: ownership remains `1` and the surviving component renders `Ready`

## Production verification

The original failure was reproduced on the authenticated LearnActive catalog route with the production v0.5.7 bundle: the query materialized three authors, the abandoned lease unsubscribed a second time, query data was detached, and compiled Pug attempted to iterate `undefined`.

Injecting the same idempotent-disposal change into that exact bundle and request flow rendered the complete catalog (`1398 Results`), including the multi-author card, with an array of three avatars and no console error.

## Validation

- `npm test`
  - Babel plugin: 30 passing
  - Teamplay server: 444 passing, 4 pending
  - Teamplay client: 127 passing
  - internal and external TypeScript checks passing
- `yarn lint`
- `yarn build`
- focused lifecycle file: 12 passing

