### PR TITLE
feat(server-aggregate): support reactive aggregation policies

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "build": "yarn workspace @teamplay/utils build && yarn workspace @teamplay/schema build && yarn workspace teamplay build",
     "clean": "rm -rf packages/utils/dist packages/schema/dist packages/teamplay/dist",
     "lint": "eslint .",
-    "test": "yarn workspace babel-plugin-teamplay test && cd packages/teamplay && npm run test",
+    "test": "yarn workspace @teamplay/server-aggregate test && yarn workspace babel-plugin-teamplay test && cd packages/teamplay && npm run test",
     "test-types:dist": "yarn build && yarn workspace teamplay test-types:dist",
     "test-client": "cd packages/teamplay && npm run test-client",
     "test-server": "cd packages/teamplay && npm run test-server",

--- a/packages/server-aggregate/README.md
+++ b/packages/server-aggregate/README.md
@@ -19,21 +19,29 @@ require('@teamplay/server-aggregate/client')
 On the server:
 
 ```js
-const serverAggregate = require('@teamplay/server-aggregate')
-serverAggregate(backend, customCheck)
+import serverAggregate from '@teamplay/server-aggregate'
+
+serverAggregate(backend, {
+  customCheck,
+  allowDirectClientAggregations: false
+})
 ```
 
 where:
 * `backend`: your ShareDB backend instance
 * `customCheck (optional)`: your personal check function. It should return an error message if there is an error. **IMPORTANT** The message must be of type `string`.
+* `allowDirectClientAggregations (optional)`: migration-only opt-in for existing direct client `$aggregate` queries. It is `false` by default. Prefer named server aggregations.
 
 ## How to add aggregation
 
-On the server side to add aggregation use `backend.addAggregate(collection, queryName, cb)`, where:
+On the server side to add aggregation use `backend.addAggregate(collection, queryName, cb, options)`, where:
 
 * `collection`: collection name
 * `queryName`: query name (alias)
 * `cb(params, shareRequest)`: async function that returns a query object or throw an error
+* `options.shouldRequery(input)`: optional synchronous mutation filter. Return `true` when the aggregation can change. Errors and non-boolean results fail open and requery.
+* `options.pollDebounce`: optional non-negative ShareDB poll debounce override
+* `options.pollInterval`: optional non-negative safety polling interval. Use `0` only when `shouldRequery` covers every relevant mutation.
 
 ```js
 backend.addAggregate('items', 'main', async (params, shareRequest) => {
@@ -44,8 +52,20 @@ backend.addAggregate('items', 'main', async (params, shareRequest) => {
   return [
     {$match: {type: 'wooden'}}
   ]
+}, {
+  pollDebounce: 0,
+  pollInterval: 3000,
+  shouldRequery ({ collection, mutation, params, context }) {
+    if (collection !== 'items') return false
+    return mutation.id === params.itemId
+  }
 })
 ```
+
+`shouldRequery` receives the concrete subscription `params`, trusted server
+`context` (`session`, root `collection`, and `isServer`), and normalized mutation
+metadata (`id`, operation type, document before, and document after). This feature
+requires a ShareDB integration which supplies that mutation metadata to `skipPoll`.
 
 ## Usage
 

--- a/packages/server-aggregate/package.json
+++ b/packages/server-aggregate/package.json
@@ -6,5 +6,8 @@
     "access": "public"
   },
   "type": "module",
-  "main": "server.js"
+  "main": "server.js",
+  "scripts": {
+    "test": "node --test test/*.test.js"
+  }
 }

--- a/packages/server-aggregate/server.js
+++ b/packages/server-aggregate/server.js
@@ -7,11 +7,19 @@ const {
   ERR_ACCESS_IN_SERVER_QUERY
 } = ACCESS_ERROR_CODES
 
-const QUERIES = {}
+export default (backend, {
+  customCheck,
+  allowDirectClientAggregations = false
+} = {}) => {
+  const queries = {}
 
-export default (backend, { customCheck } = {}) => {
-  backend.addAggregate = (collection, queryName, queryFunction) => {
-    QUERIES[collection + '.' + queryName] = queryFunction
+  backend.addAggregate = (collection, queryName, queryFunction, options = {}) => {
+    if (options.shouldRequery !== undefined && typeof options.shouldRequery !== 'function') {
+      throw TypeError('addAggregate: options.shouldRequery must be a function')
+    }
+    validatePollingOption('pollDebounce', options.pollDebounce)
+    validatePollingOption('pollInterval', options.pollInterval)
+    queries[collection + '.' + queryName] = { queryFunction, options }
   }
 
   const handleQuery = async (shareRequest) => {
@@ -21,6 +29,9 @@ export default (backend, { customCheck } = {}) => {
       const { stream } = shareRequest.agent
       // allow any aggregations initiated from the server code
       if (stream?.isServer && !stream?.checkServerAccess) return
+      // Migration mode for applications which already have direct client
+      // aggregations. Named aggregations are still resolved on the server.
+      if (allowDirectClientAggregations && !query.$aggregationName) return
       // deny any direct aggregations made from the client
       throw new ShareDBAccessError(ERR_ACCESS_ONLY_SERVER_AGGREATE, `
         access denied - only server-queries for $aggregate are allowed from the client
@@ -32,9 +43,9 @@ export default (backend, { customCheck } = {}) => {
     const { $aggregationName: queryName, $params: queryParams = {} } = query
     if (!queryName) return
 
-    const queryFunction = QUERIES[collection + '.' + queryName]
+    const definition = queries[collection + '.' + queryName]
 
-    if (!queryFunction) {
+    if (!definition) {
       throw new ShareDBAccessError(
         ERR_ACCESS_NO_SERVER_AGGREGATE_NAME,
         'there is no such server-query, name: ' +
@@ -45,7 +56,7 @@ export default (backend, { customCheck } = {}) => {
     let serverQuery
 
     try {
-      serverQuery = await queryFunction(queryParams, shareRequest)
+      serverQuery = await definition.queryFunction(queryParams, shareRequest)
     } catch (err) {
       throw new ShareDBAccessError(ERR_ACCESS_IN_SERVER_QUERY, err.message)
     }
@@ -72,6 +83,7 @@ export default (backend, { customCheck } = {}) => {
     }
 
     shareRequest.query = serverQuery
+    installLiveQueryOptions(backend, shareRequest, definition.options, queryParams)
   }
 
   backend.use('query', (shareRequest, next) => {
@@ -81,6 +93,59 @@ export default (backend, { customCheck } = {}) => {
       next(err)
     })
   })
+}
+
+function installLiveQueryOptions (backend, shareRequest, options, params) {
+  const { shouldRequery, pollDebounce, pollInterval } = options
+  shareRequest.options ||= {}
+  if (pollDebounce !== undefined) shareRequest.options.pollDebounce = pollDebounce
+  if (pollInterval !== undefined) shareRequest.options.pollInterval = pollInterval
+  if (!shouldRequery) return
+  const previousSkipPoll = shareRequest.options.skipPoll
+  const context = getAggregationContext(shareRequest)
+
+  shareRequest.options.skipPoll = (rootCollection, id, op, query, metadata) => {
+    if (previousSkipPoll?.(rootCollection, id, op, query, metadata)) return true
+    if (!metadata?.collection || !metadata.operationType) return false
+
+    const input = {
+      collection: metadata.collection,
+      mutation: {
+        id,
+        operationType: metadata.operationType,
+        before: metadata.fullDocumentBeforeChange,
+        after: metadata.fullDocument
+      },
+      params,
+      context
+    }
+
+    try {
+      const decision = shouldRequery(input)
+      if (typeof decision !== 'boolean') {
+        throw TypeError('aggregation shouldRequery must return a boolean')
+      }
+      return !decision
+    } catch (error) {
+      backend.onAggregationShouldRequeryError?.(error, input)
+      return false
+    }
+  }
+}
+
+function getAggregationContext (shareRequest) {
+  return {
+    session: shareRequest.agent.connectSession || {},
+    collection: shareRequest.collection,
+    isServer: shareRequest.agent.stream?.isServer
+  }
+}
+
+function validatePollingOption (name, value) {
+  if (value === undefined) return
+  if (!Number.isFinite(value) || value < 0) {
+    throw TypeError(`addAggregate: options.${name} must be a non-negative finite number`)
+  }
 }
 
 function isString (obj) {

--- a/packages/server-aggregate/test/server.test.js
+++ b/packages/server-aggregate/test/server.test.js
@@ -1,0 +1,241 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import serverAggregate from '../server.js'
+
+test('passes params, context and normalized lookup mutation to shouldRequery', async () => {
+  const calls = []
+  const { backend, runQuery } = setup()
+  backend.addAggregate(
+    'courses',
+    '_playerOutline',
+    ({ courseId }) => [{
+      $match: { _id: courseId }
+    }, {
+      $lookup: { from: 'stores', localField: '_id', foreignField: 'courseId', as: 'stores' }
+    }],
+    {
+      shouldRequery: input => {
+        calls.push(input)
+        return input.mutation.after?.courseId === input.params.courseId
+      }
+    }
+  )
+  const request = clientRequest({
+    $aggregationName: '_playerOutline',
+    $params: { courseId: 'course-1' }
+  })
+
+  await runQuery(request)
+
+  const skip = request.options.skipPoll('courses', 'store-1', { d: 'store-1' }, request.query, {
+    collection: 'stores',
+    operationType: 'update',
+    fullDocumentBeforeChange: { _id: 'store-1', courseId: 'course-2' },
+    fullDocument: { _id: 'store-1', courseId: 'course-1' }
+  })
+
+  assert.equal(skip, false)
+  assert.deepEqual(calls, [{
+    collection: 'stores',
+    mutation: {
+      id: 'store-1',
+      operationType: 'update',
+      before: { _id: 'store-1', courseId: 'course-2' },
+      after: { _id: 'store-1', courseId: 'course-1' }
+    },
+    params: { courseId: 'course-1' },
+    context: {
+      session: { userId: 'session-user' },
+      collection: 'courses',
+      isServer: false
+    }
+  }])
+})
+
+test('skips polling when shouldRequery marks a mutation as irrelevant', async () => {
+  const { backend, runQuery } = setup()
+  backend.addAggregate('courses', '_playerOutline', () => [], {
+    shouldRequery: () => false
+  })
+  const request = clientRequest({ $aggregationName: '_playerOutline' })
+
+  await runQuery(request)
+
+  assert.equal(request.options.skipPoll('courses', 'store-1', { d: 'store-1' }, request.query, {
+    collection: 'stores',
+    operationType: 'update',
+    fullDocumentBeforeChange: {},
+    fullDocument: {}
+  }), true)
+})
+
+test('fails open when mutation metadata is absent or shouldRequery throws', async () => {
+  const errors = []
+  const { backend, runQuery } = setup()
+  backend.onAggregationShouldRequeryError = (error, details) => errors.push({ error, details })
+  backend.addAggregate('courses', '_playerOutline', () => [], {
+    shouldRequery: () => {
+      throw new Error('broken policy')
+    }
+  })
+  const request = clientRequest({ $aggregationName: '_playerOutline' })
+
+  await runQuery(request)
+
+  assert.equal(request.options.skipPoll('courses', 'course-1', { d: 'course-1' }, request.query), false)
+  assert.equal(request.options.skipPoll('courses', 'course-1', { d: 'course-1' }, request.query, {
+    collection: 'courses',
+    operationType: 'update',
+    fullDocumentBeforeChange: {},
+    fullDocument: {}
+  }), false)
+  assert.equal(errors.length, 1)
+  assert.equal(errors[0].error.message, 'broken policy')
+})
+
+test('fails open when shouldRequery does not return a boolean', async () => {
+  const errors = []
+  const { backend, runQuery } = setup()
+  backend.onAggregationShouldRequeryError = error => errors.push(error)
+  backend.addAggregate('courses', '_playerOutline', () => [], {
+    shouldRequery: () => Promise.resolve(true)
+  })
+  const request = clientRequest({ $aggregationName: '_playerOutline' })
+
+  await runQuery(request)
+
+  assert.equal(request.options.skipPoll('courses', 'course-1', {}, request.query, {
+    collection: 'courses',
+    operationType: 'update'
+  }), false)
+  assert.equal(errors.length, 1)
+  assert.match(errors[0].message, /must return a boolean/)
+})
+
+test('keeps an existing skipPoll decision ahead of shouldRequery', async () => {
+  let policyCalls = 0
+  const { backend, runQuery } = setup()
+  backend.addAggregate('courses', '_playerOutline', () => [], {
+    shouldRequery: () => {
+      policyCalls++
+      return true
+    }
+  })
+  const request = clientRequest({ $aggregationName: '_playerOutline' })
+  request.options.skipPoll = () => true
+
+  await runQuery(request)
+
+  assert.equal(request.options.skipPoll('courses', 'course-1', {}, request.query, {
+    collection: 'courses',
+    operationType: 'update'
+  }), true)
+  assert.equal(policyCalls, 0)
+})
+
+test('applies server-defined polling options to the resolved query', async () => {
+  const { backend, runQuery } = setup()
+  backend.addAggregate('courses', '_playerOutline', () => [], {
+    pollDebounce: 15,
+    pollInterval: 0
+  })
+  const request = clientRequest({ $aggregationName: '_playerOutline' })
+
+  await runQuery(request)
+
+  assert.equal(request.options.pollDebounce, 15)
+  assert.equal(request.options.pollInterval, 0)
+})
+
+test('rejects invalid live query options at registration time', () => {
+  const { backend } = setup()
+
+  assert.throws(
+    () => backend.addAggregate('courses', 'bad-policy', () => [], { shouldRequery: true }),
+    /shouldRequery must be a function/
+  )
+  assert.throws(
+    () => backend.addAggregate('courses', 'bad-debounce', () => [], { pollDebounce: -1 }),
+    /pollDebounce must be a non-negative finite number/
+  )
+  assert.throws(
+    () => backend.addAggregate('courses', 'bad-interval', () => [], { pollInterval: Infinity }),
+    /pollInterval must be a non-negative finite number/
+  )
+})
+
+test('keeps named aggregation registries isolated between backend instances', async () => {
+  const first = setup()
+  const second = setup()
+  first.backend.addAggregate('courses', '_outline', () => [{ $match: { source: 'first' } }])
+  second.backend.addAggregate('courses', '_outline', () => [{ $match: { source: 'second' } }])
+  const firstRequest = clientRequest({ $aggregationName: '_outline' })
+  const secondRequest = clientRequest({ $aggregationName: '_outline' })
+
+  await first.runQuery(firstRequest)
+  await second.runQuery(secondRequest)
+
+  assert.deepEqual(firstRequest.query, { $aggregate: [{ $match: { source: 'first' } }] })
+  assert.deepEqual(secondRequest.query, { $aggregate: [{ $match: { source: 'second' } }] })
+})
+
+test('rejects direct client aggregations by default', async () => {
+  const { runQuery } = setup()
+
+  await assert.rejects(
+    runQuery(clientRequest({ $aggregate: [{ $match: { active: true } }] })),
+    error => error.name === 'ShareDBAccessError'
+  )
+})
+
+test('allows direct client aggregations only with explicit migration opt-in', async () => {
+  const { runQuery } = setup({ allowDirectClientAggregations: true })
+  const request = clientRequest({ $aggregate: [{ $match: { active: true } }] })
+
+  await runQuery(request)
+
+  assert.deepEqual(request.query, { $aggregate: [{ $match: { active: true } }] })
+})
+
+test('does not let migration opt-in bypass named aggregation resolution', async () => {
+  const { backend, runQuery } = setup({ allowDirectClientAggregations: true })
+  backend.addAggregate('courses', '_outline', () => [{ $match: { trusted: true } }])
+  const request = clientRequest({ $aggregationName: '_outline' })
+
+  await runQuery(request)
+
+  assert.deepEqual(request.query, { $aggregate: [{ $match: { trusted: true } }] })
+})
+
+function setup (options) {
+  let queryMiddleware
+  const backend = {
+    use (action, middleware) {
+      if (action === 'query') queryMiddleware = middleware
+    }
+  }
+
+  serverAggregate(backend, options)
+
+  return {
+    backend,
+    runQuery (request) {
+      return new Promise((resolve, reject) => {
+        queryMiddleware(request, error => error ? reject(error) : resolve())
+      })
+    }
+  }
+}
+
+function clientRequest (query) {
+  return {
+    collection: 'courses',
+    query,
+    options: {},
+    agent: {
+      connectSession: { userId: 'session-user' },
+      stream: { isServer: false }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- add per-aggregation `shouldRequery`, `pollDebounce`, and `pollInterval` options to `backend.addAggregate`
- pass normalized lookup mutation metadata together with aggregation params and trusted server context
- isolate named aggregation registries per backend and add an explicit migration opt-in for direct client aggregations
- preserve deny-by-default access and fail open when mutation relevance cannot be decided safely

## Dependency

Requires startupjs/startupjs#1330. That PR supplies lookup mutation metadata and identifies named aggregation channels inside ShareDB polling.

## TDD

- RED: 8 of 11 new tests fail against the previous implementation
- GREEN: 11 of 11 focused tests pass
- `yarn lint`
- `yarn test` (30 Babel tests, 444 server tests with 4 pending, 127 client tests)

