### PR TITLE
fix(teamplay): keep SuspenseGroup revealed after initial load

### DIFF
--- a/architecture.md
+++ b/architecture.md
@@ -460,6 +460,12 @@ rather than an individual query; incomplete render attempts fall back to the
 individual readiness promise. Cleanup is deferred by one task so React
 StrictMode subscription replay does not look like a real unmount.
 
+`SuspenseGroup` consolidates default observer boundaries only until its content
+is revealed for the first time. Once that initial content commits, observer
+boundaries become local again. This preserves the shared startup fallback while
+preventing a later interaction that mounts a suspending observer from hiding or
+restarting the entire committed group.
+
 ## Backend Features
 
 The backend layer starts in [packages/backend/index.js](./packages/backend/index.js). It composes ShareDB with TeamPlay-specific server features.

--- a/docs/guide/react-integration.md
+++ b/docs/guide/react-integration.md
@@ -116,12 +116,15 @@ function PlayerRoute ({ children }) {
 }
 ```
 
-Inside the group, default Suspense boundaries added by `observer()` are
-consolidated into the group boundary. TeamPlay automatically schedules retries
-for initial `useSub()`, `useBatchSub()`, and `useSuspendMemo()` promises, as well
-as any other thenable thrown directly while rendering an `observer()` component.
-An observer with an explicit `suspenseProps.fallback` keeps its own boundary.
-Outside `SuspenseGroup`, observer behavior is unchanged.
+Until the group reveals its content for the first time, default Suspense
+boundaries added by `observer()` are consolidated into the group boundary.
+TeamPlay automatically schedules retries for initial `useSub()`,
+`useBatchSub()`, and `useSuspendMemo()` promises, as well as any other thenable
+thrown directly while rendering an `observer()` component. After the initial
+content commits, observer boundaries become local again so a later suspended
+interaction does not hide the whole revealed group. An observer with an
+explicit `suspenseProps.fallback` always keeps its own boundary. Outside
+`SuspenseGroup`, observer behavior is unchanged.
 
 TeamPlay cannot intercept a promise thrown later by an arbitrary non-observer
 descendant because React evaluates that descendant in a separate fiber. For a

--- a/packages/teamplay/src/react/wrapIntoSuspense.js
+++ b/packages/teamplay/src/react/wrapIntoSuspense.js
@@ -6,12 +6,14 @@ import {
   memo,
   createContext,
   createElement as el,
+  Fragment,
   Suspense,
   useContext,
   useId,
   useRef
 } from 'react'
 import { pipeComponentMeta, pipeComponentDisplayName, ComponentMetaContext } from './helpers.ts'
+import useIsomorphicLayoutEffect from '../utils/useIsomorphicLayoutEffect.js'
 
 const SuspenseGroupContext = createContext()
 
@@ -25,8 +27,20 @@ export function SuspenseGroup ({ children, fallback = null }) {
   return el(
     SuspenseGroupContext.Provider,
     { value: store },
-    el(Suspense, { fallback }, children)
+    el(Suspense, { fallback },
+      el(Fragment, null,
+        children,
+        el(GroupCommitMarker, { store })
+      )
+    )
   )
+}
+
+function GroupCommitMarker ({ store }) {
+  useIsomorphicLayoutEffect(() => {
+    store.hasRevealedContent = true
+  }, [store])
+  return null
 }
 
 export function useSuspenseGroupScheduleUpdate () {
@@ -40,6 +54,7 @@ function createSuspenseGroupStore () {
 
   return {
     createdAt: Date.now(),
+    hasRevealedContent: false,
     subscribe (listener) {
       listeners.add(listener)
       return () => listeners.delete(listener)
@@ -92,7 +107,9 @@ export default function wrapIntoSuspense ({
 
   let SuspenseWrapper = (props, ref) => {
     const suspenseGroup = useContext(SuspenseGroupContext)
-    const inheritsSuspense = !!suspenseGroup
+    const inheritsSuspense = (
+      !!suspenseGroup && !suspenseGroup.hasRevealedContent
+    )
     const componentId = useId()
     const componentMetaRef = useRef()
     const admRef = useRef()

--- a/packages/teamplay/test/suspenseGroupSSR.js
+++ b/packages/teamplay/test/suspenseGroupSSR.js
@@ -1,0 +1,35 @@
+import { createElement as el } from 'react'
+import { renderToStaticMarkup } from 'react-dom/server'
+import { describe, it } from 'mocha'
+import { strict as assert } from 'node:assert'
+import { SuspenseGroup, observer } from '../src/index.ts'
+
+describe('SuspenseGroup server rendering', () => {
+  it('renders revealed content without a layout-effect warning', () => {
+    const errors = []
+    const originalConsoleError = console.error
+    console.error = (...args) => errors.push(args.join(' '))
+
+    try {
+      const Child = observer(() => el(
+        'div',
+        { 'data-testid': 'ssr-content' },
+        'Ready'
+      ))
+
+      const html = renderToStaticMarkup(
+        el(SuspenseGroup, {
+          fallback: el('div', {}, 'Loading')
+        }, el(Child))
+      )
+
+      assert.equal(html, '<div data-testid="ssr-content">Ready</div>')
+      assert.equal(
+        errors.some(message => message.includes('useLayoutEffect does nothing on the server')),
+        false
+      )
+    } finally {
+      console.error = originalConsoleError
+    }
+  })
+})

--- a/packages/teamplay/test_client/35_suspense-group.js
+++ b/packages/teamplay/test_client/35_suspense-group.js
@@ -1,4 +1,4 @@
-import { createElement as el, Suspense } from 'react'
+import { createElement as el, Fragment, Suspense, useLayoutEffect, useState } from 'react'
 import { afterEach, beforeAll, describe, expect, it } from '@jest/globals'
 import { act, cleanup, render, waitFor } from '@testing-library/react'
 import {
@@ -19,6 +19,187 @@ afterEach(cleanup)
 afterEach(runGc)
 
 describe('SuspenseGroup', () => {
+  it('keeps committed content visible while a later useSuspendMemo suspends', async () => {
+    const wake = deferred()
+    let ready = false
+
+    const Child = observer(() => {
+      useSuspendMemo(() => {
+        if (!ready) throw wake.promise
+      }, [])
+      return el('div', { 'data-testid': 'dynamic-content' }, 'Ready')
+    })
+
+    const Parent = observer(() => {
+      const [showChild, setShowChild] = useState(false)
+      return el('div', {},
+        el('button', {
+          'data-testid': 'show-dynamic-child',
+          onClick: () => setShowChild(true)
+        }, 'Show'),
+        showChild && el(Child)
+      )
+    })
+
+    const { container } = render(
+      el(SuspenseGroup, {
+        fallback: el('div', { 'data-testid': 'group-fallback' }, 'Loading')
+      }, el(Parent))
+    )
+
+    expect(container.querySelector('[data-testid="show-dynamic-child"]')).toBeTruthy()
+
+    await act(async () => {
+      container.querySelector('[data-testid="show-dynamic-child"]').click()
+      await Promise.resolve()
+    })
+
+    expect(container.querySelector('[data-testid="group-fallback"]')).toBeFalsy()
+    expect(container.querySelector('[data-testid="show-dynamic-child"]')).toBeTruthy()
+
+    await act(async () => {
+      ready = true
+      wake.resolve()
+      await wake.promise
+    })
+
+    await waitFor(() => {
+      expect(container.querySelector('[data-testid="dynamic-content"]')).toBeTruthy()
+    })
+  })
+
+  it('keeps the group revealed when an initially mounted observer suspends later', async () => {
+    const wake = deferred()
+    let ready = false
+
+    const Child = observer(({ load }) => {
+      if (load && !ready) throw wake.promise
+      return el('div', { 'data-testid': 'mounted-child' }, load ? 'Ready' : 'Idle')
+    })
+
+    const Parent = observer(() => {
+      const [load, setLoad] = useState(false)
+      return el('div', {},
+        el('button', {
+          'data-testid': 'load-mounted-child',
+          onClick: () => setLoad(true)
+        }, 'Load'),
+        el(Child, { load })
+      )
+    })
+
+    const { container } = render(
+      el(SuspenseGroup, {
+        fallback: el('div', { 'data-testid': 'group-fallback' }, 'Loading')
+      }, el(Parent))
+    )
+
+    expect(container.querySelector('[data-testid="mounted-child"]')?.textContent).toBe('Idle')
+
+    await act(async () => {
+      container.querySelector('[data-testid="load-mounted-child"]').click()
+      await Promise.resolve()
+    })
+
+    expect(container.querySelector('[data-testid="group-fallback"]')).toBeFalsy()
+    expect(container.querySelector('[data-testid="load-mounted-child"]')).toBeTruthy()
+
+    await act(async () => {
+      ready = true
+      wake.resolve()
+      await wake.promise
+    })
+
+    await waitFor(() => {
+      expect(container.querySelector('[data-testid="mounted-child"]')?.textContent).toBe('Ready')
+    })
+  })
+
+  it('marks the group revealed before layout effects mount a suspended observer', async () => {
+    const wake = deferred()
+    let ready = false
+
+    const Child = observer(() => {
+      if (!ready) throw wake.promise
+      return el('div', { 'data-testid': 'layout-effect-child' }, 'Ready')
+    })
+
+    const Parent = observer(() => {
+      const [showChild, setShowChild] = useState(false)
+      useLayoutEffect(() => {
+        setShowChild(true)
+      }, [])
+      return el('div', { 'data-testid': 'layout-effect-parent' },
+        'Parent',
+        showChild && el(Child)
+      )
+    })
+
+    const { container } = render(
+      el(SuspenseGroup, {
+        fallback: el('div', { 'data-testid': 'group-fallback' }, 'Loading')
+      }, el(Parent))
+    )
+
+    expect(container.querySelector('[data-testid="group-fallback"]')).toBeFalsy()
+    expect(container.querySelector('[data-testid="layout-effect-parent"]')).toBeTruthy()
+
+    await act(async () => {
+      ready = true
+      wake.resolve()
+      await wake.promise
+    })
+
+    await waitFor(() => {
+      expect(container.querySelector('[data-testid="layout-effect-child"]')).toBeTruthy()
+    })
+  })
+
+  it('uses the shared fallback again after the group remounts', async () => {
+    const wake = deferred()
+    let ready = true
+
+    const Child = observer(() => {
+      if (!ready) throw wake.promise
+      return el('div', { 'data-testid': 'remount-content' }, 'Ready')
+    })
+
+    const App = observer(() => {
+      const [version, setVersion] = useState(0)
+      return el(Fragment, null,
+        el('button', {
+          'data-testid': 'remount-group',
+          onClick: () => setVersion(value => value + 1)
+        }, 'Remount'),
+        el(SuspenseGroup, {
+          key: version,
+          fallback: el('div', { 'data-testid': 'group-fallback' }, 'Loading')
+        }, el(Child))
+      )
+    })
+
+    const { container } = render(el(App))
+    expect(container.querySelector('[data-testid="remount-content"]')).toBeTruthy()
+
+    ready = false
+    await act(async () => {
+      container.querySelector('[data-testid="remount-group"]').click()
+      await Promise.resolve()
+    })
+
+    expect(container.querySelector('[data-testid="group-fallback"]')).toBeTruthy()
+
+    await act(async () => {
+      ready = true
+      wake.resolve()
+      await wake.promise
+    })
+
+    await waitFor(() => {
+      expect(container.querySelector('[data-testid="remount-content"]')).toBeTruthy()
+    })
+  })
+
   it('registers any observer thenable with the group retry coordinator', async () => {
     const retries = []
     const thenable = {


### PR DESCRIPTION
## Summary

- Keep the shared SuspenseGroup fallback for initial loading only.
- Restore each observer default Suspense boundary after the group has committed content.
- Mark the first reveal with an isomorphic layout effect so layout-effect updates cannot fall into the old global boundary window.

## Why

A late observer suspension previously bubbled to the group boundary forever. In a revealed Player this hid and restarted all committed content; a dynamically created store could therefore loop indefinitely.

Related: https://github.com/dmstartups/lms/issues/4043 and https://github.com/dmstartups/lms/issues/4038

## Intentional behavior change

A later default observer suspension inside an already revealed group now uses that observer local fallback instead of the group fallback. Initial loading, group remounts, explicit observer fallbacks, and all public APIs are unchanged.

## Regression coverage

- dynamically mounted observer using useSuspendMemo
- already mounted observer that suspends on a later update
- child mounted from useLayoutEffect immediately after the first commit
- new group instance after remount returns to the shared fallback
- initial group useSub, batch, memo and arbitrary-thenable paths
- SSR render without a useLayoutEffect warning

## Validation

- yarn lint
- yarn test: 445 server passed, 4 pending; 131 client passed
- yarn build
- yarn test-types:dist
- yarn docs-build
- git diff --check